### PR TITLE
Auth unary interceptor and tests

### DIFF
--- a/cmd/kvdbserver/server/auth.go
+++ b/cmd/kvdbserver/server/auth.go
@@ -56,7 +56,7 @@ func (s *Server) AuthorizeIncomingRpcCall(ctx context.Context) error {
 	if s.passwordEnabled {
 		md, ok := metadata.FromIncomingContext(ctx)
 		if !ok {
-			return status.Errorf(codes.InvalidArgument, "%s", kvdberrors.ErrMissingMetadata)
+			return status.Error(codes.InvalidArgument, kvdberrors.ErrMissingMetadata.Error())
 		}
 
 		passwordValues := md.Get(common.GrpcMetadataKeyPassword)
@@ -67,7 +67,7 @@ func (s *Server) AuthorizeIncomingRpcCall(ctx context.Context) error {
 
 		err := s.CredentialStore.IsCorrectServerPassword([]byte(password))
 		if err != nil {
-			return status.Error(codes.Unauthenticated, "invalid credentials")
+			return status.Error(codes.Unauthenticated, kvdberrors.ErrInvalidCredentials.Error())
 		}
 	}
 	return nil

--- a/cmd/kvdbserver/server/auth_test.go
+++ b/cmd/kvdbserver/server/auth_test.go
@@ -1,0 +1,27 @@
+package server_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hollowdll/kvdb/cmd/kvdbserver/server"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetServerPassword(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		credentialStore := server.NewInMemoryCredentialStore()
+		password := "pass123"
+
+		err := credentialStore.SetServerPassword([]byte(password))
+		assert.NoErrorf(t, err, "expected no error; error = %v", err)
+	})
+
+	t.Run("PasswordTooLong", func(t *testing.T) {
+		credentialStore := server.NewInMemoryCredentialStore()
+		password := strings.Repeat("a", 73)
+
+		err := credentialStore.SetServerPassword([]byte(password))
+		assert.Error(t, err, "expected error")
+	})
+}

--- a/cmd/kvdbserver/server/auth_test.go
+++ b/cmd/kvdbserver/server/auth_test.go
@@ -1,12 +1,15 @@
 package server_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	"github.com/hollowdll/kvdb/cmd/kvdbserver/server"
+	"github.com/hollowdll/kvdb/internal/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
 )
 
 func TestSetServerPassword(t *testing.T) {
@@ -48,5 +51,35 @@ func TestIsCorrectServerPassword(t *testing.T) {
 
 		err = credentialStore.IsCorrectServerPassword([]byte("pass123?"))
 		assert.Error(t, err, "expected error")
+	})
+
+	t.Run("PasswordIsNil", func(t *testing.T) {
+		credentialStore := server.NewInMemoryCredentialStore()
+		password := "pass123"
+
+		err := credentialStore.IsCorrectServerPassword([]byte(password))
+		assert.Error(t, err, "expected error")
+	})
+}
+
+func TestAuthorizeIncomingRpcCall(t *testing.T) {
+	t.Run("PasswordEnabled", func(t *testing.T) {
+		server := server.NewServer()
+		password := "pass321"
+		server.DisableLogger()
+		server.EnablePassword()
+		server.CredentialStore.SetServerPassword([]byte(password))
+
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(common.GrpcMetadataKeyPassword, password))
+		err := server.AuthorizeIncomingRpcCall(ctx)
+		assert.NoErrorf(t, err, "expected no error; error = %s", err)
+	})
+
+	t.Run("PasswordDisabled", func(t *testing.T) {
+		server := server.NewServer()
+		server.DisableLogger()
+
+		err := server.AuthorizeIncomingRpcCall(context.Background())
+		assert.NoErrorf(t, err, "expected no error; error = %s", err)
 	})
 }

--- a/cmd/kvdbserver/server/auth_test.go
+++ b/cmd/kvdbserver/server/auth_test.go
@@ -53,7 +53,7 @@ func TestIsCorrectServerPassword(t *testing.T) {
 		assert.Error(t, err, "expected error")
 	})
 
-	t.Run("PasswordIsNil", func(t *testing.T) {
+	t.Run("PasswordIsNotSet", func(t *testing.T) {
 		credentialStore := server.NewInMemoryCredentialStore()
 		password := "pass123"
 

--- a/cmd/kvdbserver/server/auth_test.go
+++ b/cmd/kvdbserver/server/auth_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hollowdll/kvdb/cmd/kvdbserver/server"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSetServerPassword(t *testing.T) {
@@ -22,6 +23,30 @@ func TestSetServerPassword(t *testing.T) {
 		password := strings.Repeat("a", 73)
 
 		err := credentialStore.SetServerPassword([]byte(password))
+		assert.Error(t, err, "expected error")
+	})
+}
+
+func TestIsCorrectServerPassword(t *testing.T) {
+	t.Run("CorrectPassword", func(t *testing.T) {
+		credentialStore := server.NewInMemoryCredentialStore()
+		password := "pass123?"
+
+		err := credentialStore.SetServerPassword([]byte(password))
+		require.NoErrorf(t, err, "expected no error; error = %v", err)
+
+		err = credentialStore.IsCorrectServerPassword([]byte(password))
+		assert.NoErrorf(t, err, "expected no error; error = %v", err)
+	})
+
+	t.Run("IncorrectPassword", func(t *testing.T) {
+		credentialStore := server.NewInMemoryCredentialStore()
+		password := "pass123!!"
+
+		err := credentialStore.SetServerPassword([]byte(password))
+		require.NoErrorf(t, err, "expected no error; error = %v", err)
+
+		err = credentialStore.IsCorrectServerPassword([]byte("pass123?"))
 		assert.Error(t, err, "expected error")
 	})
 }

--- a/cmd/kvdbserver/server/server.go
+++ b/cmd/kvdbserver/server/server.go
@@ -51,6 +51,11 @@ func (s *Server) DisableLogger() {
 	s.logger.Disable()
 }
 
+// EnablePassword enables server password protection.
+func (s *Server) EnablePassword() {
+	s.passwordEnabled = true
+}
+
 // getTotalDataSize returns the total amount of stored data on this server in bytes.
 func (s *Server) getTotalDataSize() uint64 {
 	var sum uint64
@@ -138,7 +143,7 @@ func initServer() (*Server, *grpc.Server) {
 		if err := server.credentialStore.SetServerPassword([]byte(password)); err != nil {
 			server.logger.Fatalf("Failed to set server password: %v", err)
 		}
-		server.passwordEnabled = true
+		server.EnablePassword()
 		server.logger.Infof("Password protection is enabled. Clients need to authenticate using password.")
 	} else {
 		server.logger.Warningf("Password protection is disabled.")

--- a/cmd/kvdbserver/server/server.go
+++ b/cmd/kvdbserver/server/server.go
@@ -27,6 +27,7 @@ type Server struct {
 	startTime       time.Time
 	databases       map[string]*kvdb.Database
 	credentialStore InMemoryCredentialStore
+	// True if the server is password protected.
 	passwordEnabled bool
 	logger          kvdb.Logger
 	mutex           sync.RWMutex
@@ -143,7 +144,7 @@ func initServer() (*Server, *grpc.Server) {
 		server.logger.Warningf("Password protection is disabled.")
 	}
 
-	grpcServer := grpc.NewServer()
+	grpcServer := grpc.NewServer(grpc.UnaryInterceptor(server.authInterceptor))
 	kvdbserver.RegisterDatabaseServiceServer(grpcServer, server)
 	kvdbserver.RegisterServerServiceServer(grpcServer, server)
 	kvdbserver.RegisterStorageServiceServer(grpcServer, server)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -42,7 +42,7 @@ var (
 	// in gRPC metadata.
 	ErrMissingKeyInMetadata = errors.New("missing key in metadata")
 
-	// ErrWriteLogFile is returned when a write operation to a log file fails.
-	// Combine this with another error if needed.
-	ErrWriteLogFile = errors.New("failed to write to log file")
+	// ErrInvalidCredentials is returned in authorization process
+	// if provided credentials are incorrect.
+	ErrInvalidCredentials = errors.New("invalid credentials")
 )

--- a/internal/common/grpc.go
+++ b/internal/common/grpc.go
@@ -1,4 +1,8 @@
 package common
 
-// GrpcMetadataKeyDbName represents the gRPC metadata key for database name.
-const GrpcMetadataKeyDbName string = "database-name"
+const (
+	// GrpcMetadataKeyDbName represents the gRPC metadata key for database name.
+	GrpcMetadataKeyDbName string = "database-name"
+	// GrpcMetadataKeyPassword represents the gRPC metadata key for password.
+	GrpcMetadataKeyPassword string = "password"
+)


### PR DESCRIPTION
Adds gRPC unary interceptor for authentication that checks password. Also adds tests for InMemoryCredentialStore and auth.