### PR TITLE
Add default database setting for kvdb-cli

### DIFF
--- a/cmd/kvdb-cli/client/client.go
+++ b/cmd/kvdb-cli/client/client.go
@@ -65,5 +65,8 @@ func GetBaseGrpcMetadata() metadata.MD {
 		md.Set(common.GrpcMetadataKeyPassword, password)
 	}
 
+	dbName := viper.GetString(config.ConfigKeyDatabase)
+	md.Set(common.GrpcMetadataKeyDbName, dbName)
+
 	return md
 }

--- a/cmd/kvdb-cli/cmd/connect/set.go
+++ b/cmd/kvdb-cli/cmd/connect/set.go
@@ -7,26 +7,21 @@ import (
 )
 
 const (
-	defaultHost string = ""
-	defaultPort uint16 = 0
+	defaultHost   string = ""
+	defaultPort   uint16 = 0
+	defaultDbName string = ""
 )
 
 var (
 	host          string
 	port          uint16
+	dbName        string
 	cmdConnectSet = &cobra.Command{
 		Use:   "set",
 		Short: "Change connection settings",
 		Long:  "Change connection settings to a kvdb server",
 		Run: func(cmd *cobra.Command, args []string) {
-			if host != defaultHost {
-				viper.Set(config.ConfigKeyHost, host)
-			}
-			if port != defaultPort {
-				viper.Set(config.ConfigKeyPort, port)
-			}
-			err := viper.WriteConfig()
-			cobra.CheckErr(err)
+			setConnectionSettings()
 		},
 	}
 )
@@ -34,4 +29,19 @@ var (
 func init() {
 	cmdConnectSet.Flags().StringVarP(&host, "host", "a", defaultHost, "server address")
 	cmdConnectSet.Flags().Uint16VarP(&port, "port", "p", defaultPort, "port number")
+	cmdConnectSet.Flags().StringVarP(&dbName, "db", "d", defaultDbName, "default database")
+}
+
+func setConnectionSettings() {
+	if host != defaultHost {
+		viper.Set(config.ConfigKeyHost, host)
+	}
+	if port != defaultPort {
+		viper.Set(config.ConfigKeyPort, port)
+	}
+	if dbName != defaultDbName {
+		viper.Set(config.ConfigKeyDatabase, dbName)
+	}
+	err := viper.WriteConfig()
+	cobra.CheckErr(err)
 }

--- a/cmd/kvdb-cli/cmd/connect/show.go
+++ b/cmd/kvdb-cli/cmd/connect/show.go
@@ -20,6 +20,8 @@ var cmdConnectShow = &cobra.Command{
 func showConnectionSettings() {
 	var output string
 	output += fmt.Sprintf("Host: %s\n", viper.GetString(config.ConfigKeyHost))
-	output += fmt.Sprintf("Port: %d", viper.GetUint16(config.ConfigKeyPort))
+	output += fmt.Sprintf("Port: %d\n", viper.GetUint16(config.ConfigKeyPort))
+	output += fmt.Sprintf("Database: %s", viper.GetString(config.ConfigKeyDatabase))
+
 	fmt.Println(output)
 }

--- a/cmd/kvdb-cli/cmd/db/info.go
+++ b/cmd/kvdb-cli/cmd/db/info.go
@@ -6,8 +6,10 @@ import (
 	"time"
 
 	"github.com/hollowdll/kvdb/cmd/kvdb-cli/client"
+	"github.com/hollowdll/kvdb/cmd/kvdb-cli/config"
 	"github.com/hollowdll/kvdb/proto/kvdbserver"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -21,14 +23,16 @@ var cmdDbInfo = &cobra.Command{
 }
 
 func init() {
-	cmdDbInfo.Flags().StringVarP(&dbName, "name", "n", "", "name of the database (required)")
-	cmdDbInfo.MarkFlagRequired("name")
+	cmdDbInfo.Flags().StringVarP(&dbName, "name", "n", "", "name of the database")
 }
 
 func showDbInfo() {
 	ctx := metadata.NewOutgoingContext(context.Background(), client.GetBaseGrpcMetadata())
 	ctx, cancel := context.WithTimeout(ctx, client.CtxTimeout)
 	defer cancel()
+	if len(dbName) < 1 {
+		dbName = viper.GetString(config.ConfigKeyDatabase)
+	}
 	response, err := client.GrpcDatabaseClient.GetDatabaseInfo(ctx, &kvdbserver.GetDatabaseInfoRequest{DbName: dbName})
 	client.CheckGrpcError(err)
 

--- a/cmd/kvdb-cli/cmd/delete_key.go
+++ b/cmd/kvdb-cli/cmd/delete_key.go
@@ -27,7 +27,9 @@ func init() {
 
 func deleteKey(key string) {
 	md := client.GetBaseGrpcMetadata()
-	md.Set(common.GrpcMetadataKeyDbName, dbName)
+	if len(dbName) > 0 {
+		md.Set(common.GrpcMetadataKeyDbName, dbName)
+	}
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	ctx, cancel := context.WithTimeout(ctx, client.CtxTimeout)
 	defer cancel()

--- a/cmd/kvdb-cli/cmd/get_string.go
+++ b/cmd/kvdb-cli/cmd/get_string.go
@@ -27,7 +27,9 @@ func init() {
 
 func getString(key string) {
 	md := client.GetBaseGrpcMetadata()
-	md.Set(common.GrpcMetadataKeyDbName, dbName)
+	if len(dbName) > 0 {
+		md.Set(common.GrpcMetadataKeyDbName, dbName)
+	}
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	ctx, cancel := context.WithTimeout(ctx, client.CtxTimeout)
 	defer cancel()

--- a/cmd/kvdb-cli/cmd/set_string.go
+++ b/cmd/kvdb-cli/cmd/set_string.go
@@ -27,7 +27,9 @@ func init() {
 
 func setString(key string, value string) {
 	md := client.GetBaseGrpcMetadata()
-	md.Set(common.GrpcMetadataKeyDbName, dbName)
+	if len(dbName) > 0 {
+		md.Set(common.GrpcMetadataKeyDbName, dbName)
+	}
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	ctx, cancel := context.WithTimeout(ctx, client.CtxTimeout)
 	defer cancel()

--- a/cmd/kvdb-cli/config/config.go
+++ b/cmd/kvdb-cli/config/config.go
@@ -9,15 +9,21 @@ import (
 const (
 	configFileName string = ".kvdb-cli"
 	configFileType string = "json"
-	EnvPrefix      string = "KVDBCLI"
 
 	// ConfigKeyHost is the configuration key for host.
 	ConfigKeyHost string = "host"
 	// ConfigKeyPort is the configuration key for port.
 	ConfigKeyPort string = "port"
+	// ConfigKeyDatabase is the configuration key for default database.
+	ConfigKeyDatabase string = "default_db"
 
+	// EnvPrefix is the prefix for environment variables.
+	EnvPrefix string = "KVDBCLI"
 	// EnvVarPassword is the environment variable for password.
 	EnvVarPassword string = EnvPrefix + "_PASSWORD"
+
+	// DefaultDatabase is the name of the default database.
+	DefaultDatabase string = ""
 )
 
 // InitConfig initializes and loads configurations.
@@ -31,6 +37,7 @@ func InitConfig() {
 
 	viper.SetDefault(ConfigKeyHost, common.ServerDefaultHost)
 	viper.SetDefault(ConfigKeyPort, common.ServerDefaultPort)
+	viper.SetDefault(ConfigKeyDatabase, DefaultDatabase)
 
 	viper.SafeWriteConfig()
 	cobra.CheckErr(viper.ReadInConfig())


### PR DESCRIPTION
kvdb-cli can be configured to use default database. This adds convenience so commands like set and get don't need to explicitly specify which database to use.