### PR TITLE
Add kvdb-cli command that gets the data type of key

### DIFF
--- a/cmd/kvdb-cli/cmd/key_type.go
+++ b/cmd/kvdb-cli/cmd/key_type.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hollowdll/kvdb/cmd/kvdb-cli/client"
+	"github.com/hollowdll/kvdb/internal/common"
+	"github.com/hollowdll/kvdb/proto/kvdbserver"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc/metadata"
+)
+
+var cmdGetKeyType = &cobra.Command{
+	Use:   "keytype [key]",
+	Short: "Get the data type of a key",
+	Long:  "Get the data type of a key",
+	Args:  cobra.MatchAll(cobra.ExactArgs(1)),
+	Run: func(cmd *cobra.Command, args []string) {
+		getKeyType(args[0])
+	},
+}
+
+func init() {
+	cmdGetKeyType.Flags().StringVarP(&dbName, "database", "d", "", "database to use")
+}
+
+func getKeyType(key string) {
+	md := client.GetBaseGrpcMetadata()
+	if len(dbName) > 0 {
+		md.Set(common.GrpcMetadataKeyDbName, dbName)
+	}
+	ctx := metadata.NewOutgoingContext(context.Background(), md)
+	ctx, cancel := context.WithTimeout(ctx, client.CtxTimeout)
+	defer cancel()
+
+	response, err := client.GrpcStorageClient.GetTypeOfKey(ctx, &kvdbserver.GetTypeOfKeyRequest{Key: key})
+	client.CheckGrpcError(err)
+
+	if response.Ok {
+		fmt.Printf("\"%s\"\n", response.KeyType)
+	} else {
+		fmt.Println(client.ValueNone)
+	}
+}

--- a/cmd/kvdb-cli/cmd/root.go
+++ b/cmd/kvdb-cli/cmd/root.go
@@ -37,6 +37,7 @@ func init() {
 	rootCmd.AddCommand(cmdInfo)
 	rootCmd.AddCommand(cmdGetKeys)
 	rootCmd.AddCommand(cmdLogs)
+	rootCmd.AddCommand(cmdGetKeyType)
 
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -51,6 +51,7 @@ Common gRPC metadata for this service's RPCs:
 - `database-name`: The database to use. Required.
 
 RPCs:
+- GetTypeOfKey
 - SetString
 - GetString
 - SetHashMap

--- a/docs/kvdb-cli.md
+++ b/docs/kvdb-cli.md
@@ -345,3 +345,25 @@ $ kvdb-cli hashmap get key123 name
 $ kvdb-cli hashmap get key1 field123
 (None)
 ```
+
+## Get key type
+
+To get the data type of the value a key is holding, use command:
+```bash
+$ kvdb-cli keytype [key] -d db-name
+```
+- [key] is the name of the key.
+- Option -d specifies the name of the database. If not specified, the default database is used.
+
+For example:
+```bash
+$ kvdb-cli keytype string-key
+"String"
+```
+This gets the data type of the value that key 'string-key' is holding.
+
+If the key doesn't exist, a special value (None) is returned:
+```bash
+$ kvdb-cli keytype this-key-does-not-exist
+(None)
+```


### PR DESCRIPTION
Added a command to kvdb-cli that uses the GetTypeOfKey RPC to get the data type of a key.