### PR TITLE
Database and gRPC metadata refactoring

### DIFF
--- a/cmd/kvdbserver/server/db.go
+++ b/cmd/kvdbserver/server/db.go
@@ -19,6 +19,9 @@ func (s *Server) databaseExists(name string) bool {
 
 // CreateDatabase is the implementation of RPC CreateDatabase.
 func (s *Server) CreateDatabase(ctx context.Context, req *kvdbserver.CreateDatabaseRequest) (res *kvdbserver.CreateDatabaseResponse, err error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
 	logPrefix := "CreateDatabase"
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
@@ -28,9 +31,6 @@ func (s *Server) CreateDatabase(ctx context.Context, req *kvdbserver.CreateDatab
 			s.logger.Infof("Created database '%s'", req.GetDbName())
 		}
 	}()
-
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
 
 	if s.databaseExists(req.GetDbName()) {
 		return nil, status.Error(codes.AlreadyExists, kvdberrors.ErrDatabaseExists.Error())
@@ -48,6 +48,9 @@ func (s *Server) CreateDatabase(ctx context.Context, req *kvdbserver.CreateDatab
 
 // GetAllDatabases is the implementation of RPC GetAllDatabases.
 func (s *Server) GetAllDatabases(ctx context.Context, req *kvdbserver.GetAllDatabasesRequest) (res *kvdbserver.GetAllDatabasesResponse, err error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
 	logPrefix := "GetAllDatabases"
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
@@ -57,9 +60,6 @@ func (s *Server) GetAllDatabases(ctx context.Context, req *kvdbserver.GetAllData
 			s.logger.Debugf("%s: (success) %v", logPrefix, req)
 		}
 	}()
-
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
 
 	var names []string
 	for key := range s.databases {
@@ -71,6 +71,9 @@ func (s *Server) GetAllDatabases(ctx context.Context, req *kvdbserver.GetAllData
 
 // GetDatabaseInfo is the implementation of RPC GetDatabaseInfo.
 func (s *Server) GetDatabaseInfo(ctx context.Context, req *kvdbserver.GetDatabaseInfoRequest) (res *kvdbserver.GetDatabaseInfoResponse, err error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
 	logPrefix := "GetDatabaseInfo"
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
@@ -80,9 +83,6 @@ func (s *Server) GetDatabaseInfo(ctx context.Context, req *kvdbserver.GetDatabas
 			s.logger.Debugf("%s: (success) %v", logPrefix, req)
 		}
 	}()
-
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
 
 	if !s.databaseExists(req.GetDbName()) {
 		return nil, status.Error(codes.NotFound, kvdberrors.ErrDatabaseNotFound.Error())
@@ -102,6 +102,9 @@ func (s *Server) GetDatabaseInfo(ctx context.Context, req *kvdbserver.GetDatabas
 
 // DeleteDatabase is the implementation of RPC DeleteDatabase.
 func (s *Server) DeleteDatabase(ctx context.Context, req *kvdbserver.DeleteDatabaseRequest) (res *kvdbserver.DeleteDatabaseResponse, err error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
 	logPrefix := "DeleteDatabase"
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
@@ -111,9 +114,6 @@ func (s *Server) DeleteDatabase(ctx context.Context, req *kvdbserver.DeleteDatab
 			s.logger.Infof("Deleted database '%s'", req.GetDbName())
 		}
 	}()
-
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
 
 	if !s.databaseExists(req.GetDbName()) {
 		return nil, status.Error(codes.NotFound, kvdberrors.ErrDatabaseNotFound.Error())

--- a/cmd/kvdbserver/server/server.go
+++ b/cmd/kvdbserver/server/server.go
@@ -209,6 +209,9 @@ func getOsInfo() (string, error) {
 
 // GetServerInfo is the implementation of RPC GetServerInfo.
 func (s *Server) GetServerInfo(ctx context.Context, req *kvdbserver.GetServerInfoRequest) (res *kvdbserver.GetServerInfoResponse, err error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
 	logPrefix := "GetServerInfo"
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
@@ -223,9 +226,6 @@ func (s *Server) GetServerInfo(ctx context.Context, req *kvdbserver.GetServerInf
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
 
 	info := &kvdbserver.ServerInfo{
 		KvdbVersion:   version.Version,
@@ -244,6 +244,9 @@ func (s *Server) GetServerInfo(ctx context.Context, req *kvdbserver.GetServerInf
 
 // GetLogs is the implementation of RPC GetLogs.
 func (s *Server) GetLogs(ctx context.Context, req *kvdbserver.GetLogsRequest) (res *kvdbserver.GetLogsResponse, err error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
 	logPrefix := "GetLogs"
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
@@ -253,9 +256,6 @@ func (s *Server) GetLogs(ctx context.Context, req *kvdbserver.GetLogsRequest) (r
 			s.logger.Debugf("%s: (success) %v", logPrefix, req)
 		}
 	}()
-
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
 
 	if !s.logFileEnabled {
 		return nil, status.Errorf(codes.FailedPrecondition, "%s: enable server log file to get logs", kvdberrors.ErrLogFileNotEnabled.Error())

--- a/cmd/kvdbserver/server/storage.go
+++ b/cmd/kvdbserver/server/storage.go
@@ -5,18 +5,15 @@ import (
 
 	kvdb "github.com/hollowdll/kvdb"
 	kvdberrors "github.com/hollowdll/kvdb/errors"
-	"github.com/hollowdll/kvdb/internal/common"
 	"github.com/hollowdll/kvdb/proto/kvdbserver"
-	"github.com/spf13/viper"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
 // GetTypeOfKey is the implementation of RPC GetTypeOfKey.
 func (s *Server) GetTypeOfKey(ctx context.Context, req *kvdbserver.GetTypeOfKeyRequest) (res *kvdbserver.GetTypeOfKeyResponse, err error) {
 	logPrefix := "GetTypeOfKey"
-	dbName := getDatabaseNameFromContext(ctx)
+	dbName := s.getDatabaseNameFromContext(ctx)
 
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
@@ -42,7 +39,7 @@ func (s *Server) GetTypeOfKey(ctx context.Context, req *kvdbserver.GetTypeOfKeyR
 // SetString is the implementation of RPC SetString.
 func (s *Server) SetString(ctx context.Context, req *kvdbserver.SetStringRequest) (res *kvdbserver.SetStringResponse, err error) {
 	logPrefix := "SetString"
-	dbName := getDatabaseNameFromContext(ctx)
+	dbName := s.getDatabaseNameFromContext(ctx)
 
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
@@ -76,7 +73,7 @@ func (s *Server) SetString(ctx context.Context, req *kvdbserver.SetStringRequest
 // GetString is the implementation of RPC GetString.
 func (s *Server) GetString(ctx context.Context, req *kvdbserver.GetStringRequest) (res *kvdbserver.GetStringResponse, err error) {
 	logPrefix := "GetString"
-	dbName := getDatabaseNameFromContext(ctx)
+	dbName := s.getDatabaseNameFromContext(ctx)
 
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
@@ -102,7 +99,7 @@ func (s *Server) GetString(ctx context.Context, req *kvdbserver.GetStringRequest
 // DeleteKey is the implementation of RPC DeleteKey.
 func (s *Server) DeleteKey(ctx context.Context, req *kvdbserver.DeleteKeyRequest) (res *kvdbserver.DeleteKeyResponse, err error) {
 	logPrefix := "DeleteKey"
-	dbName := getDatabaseNameFromContext(ctx)
+	dbName := s.getDatabaseNameFromContext(ctx)
 
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
@@ -131,7 +128,7 @@ func (s *Server) DeleteKey(ctx context.Context, req *kvdbserver.DeleteKeyRequest
 // DeleteAllKeys is the implementation of RPC DeleteAllKeys.
 func (s *Server) DeleteAllKeys(ctx context.Context, req *kvdbserver.DeleteAllKeysRequest) (res *kvdbserver.DeleteAllKeysResponse, err error) {
 	logPrefix := "DeleteAllKeys"
-	dbName := getDatabaseNameFromContext(ctx)
+	dbName := s.getDatabaseNameFromContext(ctx)
 
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
@@ -157,7 +154,7 @@ func (s *Server) DeleteAllKeys(ctx context.Context, req *kvdbserver.DeleteAllKey
 // GetKeys is the implementation of RPC GetKeys.
 func (s *Server) GetKeys(ctx context.Context, req *kvdbserver.GetKeysRequest) (res *kvdbserver.GetKeysResponse, err error) {
 	logPrefix := "GetKeys"
-	dbName := getDatabaseNameFromContext(ctx)
+	dbName := s.getDatabaseNameFromContext(ctx)
 
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
@@ -181,7 +178,7 @@ func (s *Server) GetKeys(ctx context.Context, req *kvdbserver.GetKeysRequest) (r
 // SetHashMap is the implementation of RPC SetHashMap.
 func (s *Server) SetHashMap(ctx context.Context, req *kvdbserver.SetHashMapRequest) (res *kvdbserver.SetHashMapResponse, err error) {
 	logPrefix := "SetHashMap"
-	dbName := getDatabaseNameFromContext(ctx)
+	dbName := s.getDatabaseNameFromContext(ctx)
 
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
@@ -215,7 +212,7 @@ func (s *Server) SetHashMap(ctx context.Context, req *kvdbserver.SetHashMapReque
 // GetHashMapFieldValue is the implementation of RPC GetHashMapFieldValue.
 func (s *Server) GetHashMapFieldValue(ctx context.Context, req *kvdbserver.GetHashMapFieldValueRequest) (res *kvdbserver.GetHashMapFieldValueResponse, err error) {
 	logPrefix := "GetHashMapFieldValue"
-	dbName := getDatabaseNameFromContext(ctx)
+	dbName := s.getDatabaseNameFromContext(ctx)
 
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
@@ -241,7 +238,7 @@ func (s *Server) GetHashMapFieldValue(ctx context.Context, req *kvdbserver.GetHa
 // DeleteHashMapFields is the implementation of RPC DeleteHashMapFields.
 func (s *Server) DeleteHashMapFields(ctx context.Context, req *kvdbserver.DeleteHashMapFieldsRequest) (res *kvdbserver.DeleteHashMapFieldsResponse, err error) {
 	logPrefix := "DeleteHashMapFields"
-	dbName := getDatabaseNameFromContext(ctx)
+	dbName := s.getDatabaseNameFromContext(ctx)
 
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
@@ -267,7 +264,7 @@ func (s *Server) DeleteHashMapFields(ctx context.Context, req *kvdbserver.Delete
 // GetAllHashMapFieldsAndValues is the implementation of RPC GetAllHashMapFieldsAndValues.
 func (s *Server) GetAllHashMapFieldsAndValues(ctx context.Context, req *kvdbserver.GetAllHashMapFieldsAndValuesRequest) (res *kvdbserver.GetAllHashMapFieldsAndValuesResponse, err error) {
 	logPrefix := "GetAllHashMapFieldsAndValues"
-	dbName := getDatabaseNameFromContext(ctx)
+	dbName := s.getDatabaseNameFromContext(ctx)
 
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
@@ -288,19 +285,4 @@ func (s *Server) GetAllHashMapFieldsAndValues(ctx context.Context, req *kvdbserv
 	fieldValueMap, ok := s.databases[dbName].GetAllHashMapFieldsAndValues(kvdb.DatabaseKey(req.Key))
 
 	return &kvdbserver.GetAllHashMapFieldsAndValuesResponse{FieldValueMap: fieldValueMap, Ok: ok}, nil
-}
-
-// getDatabaseNameFromContext gets the database name from the incoming gRPC metadata.
-func getDatabaseNameFromContext(ctx context.Context) string {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		return viper.GetString(ConfigKeyDefaultDatabase)
-	}
-
-	dbName := md.Get(common.GrpcMetadataKeyDbName)
-	if len(dbName) < 1 {
-		return viper.GetString(ConfigKeyDefaultDatabase)
-	}
-
-	return dbName[0]
 }

--- a/cmd/kvdbserver/server/storage.go
+++ b/cmd/kvdbserver/server/storage.go
@@ -104,12 +104,12 @@ func (s *Server) DeleteKey(ctx context.Context, req *kvdbserver.DeleteKeyRequest
 	logPrefix := "DeleteKey"
 	dbName := s.getDatabaseNameFromContext(ctx)
 
-	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
+	s.logger.Debugf("%s: (attempt) db = %s %v", logPrefix, dbName, req)
 	defer func() {
 		if err != nil {
 			s.logger.Errorf("%s: operation failed: %v", logPrefix, err)
 		} else {
-			s.logger.Debugf("%s: (success) %v", logPrefix, req)
+			s.logger.Debugf("%s: (success) db = %s %v", logPrefix, dbName, req)
 		}
 	}()
 
@@ -133,12 +133,12 @@ func (s *Server) DeleteAllKeys(ctx context.Context, req *kvdbserver.DeleteAllKey
 	logPrefix := "DeleteAllKeys"
 	dbName := s.getDatabaseNameFromContext(ctx)
 
-	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
+	s.logger.Debugf("%s: (attempt) db = %s %v", logPrefix, dbName, req)
 	defer func() {
 		if err != nil {
 			s.logger.Errorf("%s: operation failed: %v", logPrefix, err)
 		} else {
-			s.logger.Debugf("%s: (success) %v", logPrefix, req)
+			s.logger.Debugf("%s: (success) db = %s %v", logPrefix, dbName, req)
 		}
 	}()
 
@@ -159,12 +159,12 @@ func (s *Server) GetKeys(ctx context.Context, req *kvdbserver.GetKeysRequest) (r
 	logPrefix := "GetKeys"
 	dbName := s.getDatabaseNameFromContext(ctx)
 
-	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
+	s.logger.Debugf("%s: (attempt) db = %s %v", logPrefix, dbName, req)
 	defer func() {
 		if err != nil {
 			s.logger.Errorf("%s: operation failed: %v", logPrefix, err)
 		} else {
-			s.logger.Debugf("%s: (success) %v", logPrefix, req)
+			s.logger.Debugf("%s: (success) db = %s %v", logPrefix, dbName, req)
 		}
 	}()
 
@@ -183,12 +183,12 @@ func (s *Server) SetHashMap(ctx context.Context, req *kvdbserver.SetHashMapReque
 	logPrefix := "SetHashMap"
 	dbName := s.getDatabaseNameFromContext(ctx)
 
-	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
+	s.logger.Debugf("%s: (attempt) db = %s %v", logPrefix, dbName, req)
 	defer func() {
 		if err != nil {
 			s.logger.Errorf("%s: operation failed: %v", logPrefix, err)
 		} else {
-			s.logger.Debugf("%s: (success) %v", logPrefix, req)
+			s.logger.Debugf("%s: (success) db = %s %v", logPrefix, dbName, req)
 		}
 	}()
 
@@ -217,12 +217,12 @@ func (s *Server) GetHashMapFieldValue(ctx context.Context, req *kvdbserver.GetHa
 	logPrefix := "GetHashMapFieldValue"
 	dbName := s.getDatabaseNameFromContext(ctx)
 
-	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
+	s.logger.Debugf("%s: (attempt) db = %s %v", logPrefix, dbName, req)
 	defer func() {
 		if err != nil {
 			s.logger.Errorf("%s: operation failed: %v", logPrefix, err)
 		} else {
-			s.logger.Debugf("%s: (success) %v", logPrefix, req)
+			s.logger.Debugf("%s: (success) db = %s %v", logPrefix, dbName, req)
 		}
 	}()
 
@@ -243,12 +243,12 @@ func (s *Server) DeleteHashMapFields(ctx context.Context, req *kvdbserver.Delete
 	logPrefix := "DeleteHashMapFields"
 	dbName := s.getDatabaseNameFromContext(ctx)
 
-	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
+	s.logger.Debugf("%s: (attempt) db = %s %v", logPrefix, dbName, req)
 	defer func() {
 		if err != nil {
 			s.logger.Errorf("%s: operation failed: %v", logPrefix, err)
 		} else {
-			s.logger.Debugf("%s: (success) %v", logPrefix, req)
+			s.logger.Debugf("%s: (success) db = %s %v", logPrefix, dbName, req)
 		}
 	}()
 
@@ -269,12 +269,12 @@ func (s *Server) GetAllHashMapFieldsAndValues(ctx context.Context, req *kvdbserv
 	logPrefix := "GetAllHashMapFieldsAndValues"
 	dbName := s.getDatabaseNameFromContext(ctx)
 
-	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
+	s.logger.Debugf("%s: (attempt) db = %s %v", logPrefix, dbName, req)
 	defer func() {
 		if err != nil {
 			s.logger.Errorf("%s: operation failed: %v", logPrefix, err)
 		} else {
-			s.logger.Debugf("%s: (success) %v", logPrefix, req)
+			s.logger.Debugf("%s: (success) db = %s %v", logPrefix, dbName, req)
 		}
 	}()
 

--- a/cmd/kvdbserver/server/storage.go
+++ b/cmd/kvdbserver/server/storage.go
@@ -7,6 +7,7 @@ import (
 	kvdberrors "github.com/hollowdll/kvdb/errors"
 	"github.com/hollowdll/kvdb/internal/common"
 	"github.com/hollowdll/kvdb/proto/kvdbserver"
+	"github.com/spf13/viper"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -15,6 +16,8 @@ import (
 // GetTypeOfKey is the implementation of RPC GetTypeOfKey.
 func (s *Server) GetTypeOfKey(ctx context.Context, req *kvdbserver.GetTypeOfKeyRequest) (res *kvdbserver.GetTypeOfKeyResponse, err error) {
 	logPrefix := "GetTypeOfKey"
+	dbName := getDatabaseNameFromContext(ctx)
+
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
 		if err != nil {
@@ -23,11 +26,6 @@ func (s *Server) GetTypeOfKey(ctx context.Context, req *kvdbserver.GetTypeOfKeyR
 			s.logger.Debugf("%s: (success) %v", logPrefix, req)
 		}
 	}()
-
-	dbName, err := getDatabaseNameFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
@@ -44,6 +42,8 @@ func (s *Server) GetTypeOfKey(ctx context.Context, req *kvdbserver.GetTypeOfKeyR
 // SetString is the implementation of RPC SetString.
 func (s *Server) SetString(ctx context.Context, req *kvdbserver.SetStringRequest) (res *kvdbserver.SetStringResponse, err error) {
 	logPrefix := "SetString"
+	dbName := getDatabaseNameFromContext(ctx)
+
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
 		if err != nil {
@@ -52,11 +52,6 @@ func (s *Server) SetString(ctx context.Context, req *kvdbserver.SetStringRequest
 			s.logger.Debugf("%s: (success) %v", logPrefix, req)
 		}
 	}()
-
-	dbName, err := getDatabaseNameFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
@@ -81,6 +76,8 @@ func (s *Server) SetString(ctx context.Context, req *kvdbserver.SetStringRequest
 // GetString is the implementation of RPC GetString.
 func (s *Server) GetString(ctx context.Context, req *kvdbserver.GetStringRequest) (res *kvdbserver.GetStringResponse, err error) {
 	logPrefix := "GetString"
+	dbName := getDatabaseNameFromContext(ctx)
+
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
 		if err != nil {
@@ -89,11 +86,6 @@ func (s *Server) GetString(ctx context.Context, req *kvdbserver.GetStringRequest
 			s.logger.Debugf("%s: (success) %v", logPrefix, req)
 		}
 	}()
-
-	dbName, err := getDatabaseNameFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
@@ -110,6 +102,8 @@ func (s *Server) GetString(ctx context.Context, req *kvdbserver.GetStringRequest
 // DeleteKey is the implementation of RPC DeleteKey.
 func (s *Server) DeleteKey(ctx context.Context, req *kvdbserver.DeleteKeyRequest) (res *kvdbserver.DeleteKeyResponse, err error) {
 	logPrefix := "DeleteKey"
+	dbName := getDatabaseNameFromContext(ctx)
+
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
 		if err != nil {
@@ -118,11 +112,6 @@ func (s *Server) DeleteKey(ctx context.Context, req *kvdbserver.DeleteKeyRequest
 			s.logger.Debugf("%s: (success) %v", logPrefix, req)
 		}
 	}()
-
-	dbName, err := getDatabaseNameFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
@@ -142,6 +131,8 @@ func (s *Server) DeleteKey(ctx context.Context, req *kvdbserver.DeleteKeyRequest
 // DeleteAllKeys is the implementation of RPC DeleteAllKeys.
 func (s *Server) DeleteAllKeys(ctx context.Context, req *kvdbserver.DeleteAllKeysRequest) (res *kvdbserver.DeleteAllKeysResponse, err error) {
 	logPrefix := "DeleteAllKeys"
+	dbName := getDatabaseNameFromContext(ctx)
+
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
 		if err != nil {
@@ -150,11 +141,6 @@ func (s *Server) DeleteAllKeys(ctx context.Context, req *kvdbserver.DeleteAllKey
 			s.logger.Debugf("%s: (success) %v", logPrefix, req)
 		}
 	}()
-
-	dbName, err := getDatabaseNameFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
@@ -171,6 +157,8 @@ func (s *Server) DeleteAllKeys(ctx context.Context, req *kvdbserver.DeleteAllKey
 // GetKeys is the implementation of RPC GetKeys.
 func (s *Server) GetKeys(ctx context.Context, req *kvdbserver.GetKeysRequest) (res *kvdbserver.GetKeysResponse, err error) {
 	logPrefix := "GetKeys"
+	dbName := getDatabaseNameFromContext(ctx)
+
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
 		if err != nil {
@@ -179,11 +167,6 @@ func (s *Server) GetKeys(ctx context.Context, req *kvdbserver.GetKeysRequest) (r
 			s.logger.Debugf("%s: (success) %v", logPrefix, req)
 		}
 	}()
-
-	dbName, err := getDatabaseNameFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
@@ -198,6 +181,8 @@ func (s *Server) GetKeys(ctx context.Context, req *kvdbserver.GetKeysRequest) (r
 // SetHashMap is the implementation of RPC SetHashMap.
 func (s *Server) SetHashMap(ctx context.Context, req *kvdbserver.SetHashMapRequest) (res *kvdbserver.SetHashMapResponse, err error) {
 	logPrefix := "SetHashMap"
+	dbName := getDatabaseNameFromContext(ctx)
+
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
 		if err != nil {
@@ -206,11 +191,6 @@ func (s *Server) SetHashMap(ctx context.Context, req *kvdbserver.SetHashMapReque
 			s.logger.Debugf("%s: (success) %v", logPrefix, req)
 		}
 	}()
-
-	dbName, err := getDatabaseNameFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
@@ -235,6 +215,8 @@ func (s *Server) SetHashMap(ctx context.Context, req *kvdbserver.SetHashMapReque
 // GetHashMapFieldValue is the implementation of RPC GetHashMapFieldValue.
 func (s *Server) GetHashMapFieldValue(ctx context.Context, req *kvdbserver.GetHashMapFieldValueRequest) (res *kvdbserver.GetHashMapFieldValueResponse, err error) {
 	logPrefix := "GetHashMapFieldValue"
+	dbName := getDatabaseNameFromContext(ctx)
+
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
 		if err != nil {
@@ -243,11 +225,6 @@ func (s *Server) GetHashMapFieldValue(ctx context.Context, req *kvdbserver.GetHa
 			s.logger.Debugf("%s: (success) %v", logPrefix, req)
 		}
 	}()
-
-	dbName, err := getDatabaseNameFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
@@ -264,6 +241,8 @@ func (s *Server) GetHashMapFieldValue(ctx context.Context, req *kvdbserver.GetHa
 // DeleteHashMapFields is the implementation of RPC DeleteHashMapFields.
 func (s *Server) DeleteHashMapFields(ctx context.Context, req *kvdbserver.DeleteHashMapFieldsRequest) (res *kvdbserver.DeleteHashMapFieldsResponse, err error) {
 	logPrefix := "DeleteHashMapFields"
+	dbName := getDatabaseNameFromContext(ctx)
+
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
 		if err != nil {
@@ -272,11 +251,6 @@ func (s *Server) DeleteHashMapFields(ctx context.Context, req *kvdbserver.Delete
 			s.logger.Debugf("%s: (success) %v", logPrefix, req)
 		}
 	}()
-
-	dbName, err := getDatabaseNameFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
@@ -293,6 +267,8 @@ func (s *Server) DeleteHashMapFields(ctx context.Context, req *kvdbserver.Delete
 // GetAllHashMapFieldsAndValues is the implementation of RPC GetAllHashMapFieldsAndValues.
 func (s *Server) GetAllHashMapFieldsAndValues(ctx context.Context, req *kvdbserver.GetAllHashMapFieldsAndValuesRequest) (res *kvdbserver.GetAllHashMapFieldsAndValuesResponse, err error) {
 	logPrefix := "GetAllHashMapFieldsAndValues"
+	dbName := getDatabaseNameFromContext(ctx)
+
 	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
 	defer func() {
 		if err != nil {
@@ -301,11 +277,6 @@ func (s *Server) GetAllHashMapFieldsAndValues(ctx context.Context, req *kvdbserv
 			s.logger.Debugf("%s: (success) %v", logPrefix, req)
 		}
 	}()
-
-	dbName, err := getDatabaseNameFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
 
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
@@ -319,17 +290,17 @@ func (s *Server) GetAllHashMapFieldsAndValues(ctx context.Context, req *kvdbserv
 	return &kvdbserver.GetAllHashMapFieldsAndValuesResponse{FieldValueMap: fieldValueMap, Ok: ok}, nil
 }
 
-// getDatabaseNameFromContext gets the database name from the received gRPC metadata.
-func getDatabaseNameFromContext(ctx context.Context) (string, error) {
+// getDatabaseNameFromContext gets the database name from the incoming gRPC metadata.
+func getDatabaseNameFromContext(ctx context.Context) string {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return "", status.Error(codes.InvalidArgument, kvdberrors.ErrMissingMetadata.Error())
+		return viper.GetString(ConfigKeyDefaultDatabase)
 	}
 
 	dbName := md.Get(common.GrpcMetadataKeyDbName)
 	if len(dbName) < 1 {
-		return "", status.Errorf(codes.InvalidArgument, "%s (%s)", kvdberrors.ErrMissingKeyInMetadata, common.GrpcMetadataKeyDbName)
+		return viper.GetString(ConfigKeyDefaultDatabase)
 	}
 
-	return dbName[0], nil
+	return dbName[0]
 }

--- a/cmd/kvdbserver/server/storage.go
+++ b/cmd/kvdbserver/server/storage.go
@@ -12,20 +12,20 @@ import (
 
 // GetTypeOfKey is the implementation of RPC GetTypeOfKey.
 func (s *Server) GetTypeOfKey(ctx context.Context, req *kvdbserver.GetTypeOfKeyRequest) (res *kvdbserver.GetTypeOfKeyResponse, err error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
 	logPrefix := "GetTypeOfKey"
 	dbName := s.getDatabaseNameFromContext(ctx)
 
-	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
+	s.logger.Debugf("%s: (attempt) db = %s %v", logPrefix, dbName, req)
 	defer func() {
 		if err != nil {
 			s.logger.Errorf("%s: operation failed: %v", logPrefix, err)
 		} else {
-			s.logger.Debugf("%s: (success) %v", logPrefix, req)
+			s.logger.Debugf("%s: (success) db = %s %v", logPrefix, dbName, req)
 		}
 	}()
-
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
 
 	if !s.databaseExists(dbName) {
 		return nil, status.Error(codes.NotFound, kvdberrors.ErrDatabaseNotFound.Error())
@@ -38,20 +38,20 @@ func (s *Server) GetTypeOfKey(ctx context.Context, req *kvdbserver.GetTypeOfKeyR
 
 // SetString is the implementation of RPC SetString.
 func (s *Server) SetString(ctx context.Context, req *kvdbserver.SetStringRequest) (res *kvdbserver.SetStringResponse, err error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
 	logPrefix := "SetString"
 	dbName := s.getDatabaseNameFromContext(ctx)
 
-	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
+	s.logger.Debugf("%s: (attempt) db = %s %v", logPrefix, dbName, req)
 	defer func() {
 		if err != nil {
 			s.logger.Errorf("%s: operation failed: %v", logPrefix, err)
 		} else {
-			s.logger.Debugf("%s: (success) %v", logPrefix, req)
+			s.logger.Debugf("%s: (success) db = %s %v", logPrefix, dbName, req)
 		}
 	}()
-
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
 
 	if !s.databaseExists(dbName) {
 		return nil, status.Error(codes.NotFound, kvdberrors.ErrDatabaseNotFound.Error())
@@ -72,20 +72,20 @@ func (s *Server) SetString(ctx context.Context, req *kvdbserver.SetStringRequest
 
 // GetString is the implementation of RPC GetString.
 func (s *Server) GetString(ctx context.Context, req *kvdbserver.GetStringRequest) (res *kvdbserver.GetStringResponse, err error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
 	logPrefix := "GetString"
 	dbName := s.getDatabaseNameFromContext(ctx)
 
-	s.logger.Debugf("%s: (attempt) %v", logPrefix, req)
+	s.logger.Debugf("%s: (attempt) db = %s %v", logPrefix, dbName, req)
 	defer func() {
 		if err != nil {
 			s.logger.Errorf("%s: operation failed: %v", logPrefix, err)
 		} else {
-			s.logger.Debugf("%s: (success) %v", logPrefix, req)
+			s.logger.Debugf("%s: (success) db = %s %v", logPrefix, dbName, req)
 		}
 	}()
-
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
 
 	if !s.databaseExists(dbName) {
 		return nil, status.Error(codes.NotFound, kvdberrors.ErrDatabaseNotFound.Error())
@@ -98,6 +98,9 @@ func (s *Server) GetString(ctx context.Context, req *kvdbserver.GetStringRequest
 
 // DeleteKey is the implementation of RPC DeleteKey.
 func (s *Server) DeleteKey(ctx context.Context, req *kvdbserver.DeleteKeyRequest) (res *kvdbserver.DeleteKeyResponse, err error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
 	logPrefix := "DeleteKey"
 	dbName := s.getDatabaseNameFromContext(ctx)
 
@@ -109,9 +112,6 @@ func (s *Server) DeleteKey(ctx context.Context, req *kvdbserver.DeleteKeyRequest
 			s.logger.Debugf("%s: (success) %v", logPrefix, req)
 		}
 	}()
-
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
 
 	if !s.databaseExists(dbName) {
 		return nil, status.Error(codes.NotFound, kvdberrors.ErrDatabaseNotFound.Error())
@@ -127,6 +127,9 @@ func (s *Server) DeleteKey(ctx context.Context, req *kvdbserver.DeleteKeyRequest
 
 // DeleteAllKeys is the implementation of RPC DeleteAllKeys.
 func (s *Server) DeleteAllKeys(ctx context.Context, req *kvdbserver.DeleteAllKeysRequest) (res *kvdbserver.DeleteAllKeysResponse, err error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
 	logPrefix := "DeleteAllKeys"
 	dbName := s.getDatabaseNameFromContext(ctx)
 
@@ -139,9 +142,6 @@ func (s *Server) DeleteAllKeys(ctx context.Context, req *kvdbserver.DeleteAllKey
 		}
 	}()
 
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
-
 	if !s.databaseExists(dbName) {
 		return nil, status.Error(codes.NotFound, kvdberrors.ErrDatabaseNotFound.Error())
 	}
@@ -153,6 +153,9 @@ func (s *Server) DeleteAllKeys(ctx context.Context, req *kvdbserver.DeleteAllKey
 
 // GetKeys is the implementation of RPC GetKeys.
 func (s *Server) GetKeys(ctx context.Context, req *kvdbserver.GetKeysRequest) (res *kvdbserver.GetKeysResponse, err error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
 	logPrefix := "GetKeys"
 	dbName := s.getDatabaseNameFromContext(ctx)
 
@@ -165,9 +168,6 @@ func (s *Server) GetKeys(ctx context.Context, req *kvdbserver.GetKeysRequest) (r
 		}
 	}()
 
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
-
 	if !s.databaseExists(dbName) {
 		return nil, status.Error(codes.NotFound, kvdberrors.ErrDatabaseNotFound.Error())
 	}
@@ -177,6 +177,9 @@ func (s *Server) GetKeys(ctx context.Context, req *kvdbserver.GetKeysRequest) (r
 
 // SetHashMap is the implementation of RPC SetHashMap.
 func (s *Server) SetHashMap(ctx context.Context, req *kvdbserver.SetHashMapRequest) (res *kvdbserver.SetHashMapResponse, err error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
 	logPrefix := "SetHashMap"
 	dbName := s.getDatabaseNameFromContext(ctx)
 
@@ -188,9 +191,6 @@ func (s *Server) SetHashMap(ctx context.Context, req *kvdbserver.SetHashMapReque
 			s.logger.Debugf("%s: (success) %v", logPrefix, req)
 		}
 	}()
-
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
 
 	if !s.databaseExists(dbName) {
 		return nil, status.Error(codes.NotFound, kvdberrors.ErrDatabaseNotFound.Error())
@@ -211,6 +211,9 @@ func (s *Server) SetHashMap(ctx context.Context, req *kvdbserver.SetHashMapReque
 
 // GetHashMapFieldValue is the implementation of RPC GetHashMapFieldValue.
 func (s *Server) GetHashMapFieldValue(ctx context.Context, req *kvdbserver.GetHashMapFieldValueRequest) (res *kvdbserver.GetHashMapFieldValueResponse, err error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
 	logPrefix := "GetHashMapFieldValue"
 	dbName := s.getDatabaseNameFromContext(ctx)
 
@@ -223,9 +226,6 @@ func (s *Server) GetHashMapFieldValue(ctx context.Context, req *kvdbserver.GetHa
 		}
 	}()
 
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
-
 	if !s.databaseExists(dbName) {
 		return nil, status.Error(codes.NotFound, kvdberrors.ErrDatabaseNotFound.Error())
 	}
@@ -237,6 +237,9 @@ func (s *Server) GetHashMapFieldValue(ctx context.Context, req *kvdbserver.GetHa
 
 // DeleteHashMapFields is the implementation of RPC DeleteHashMapFields.
 func (s *Server) DeleteHashMapFields(ctx context.Context, req *kvdbserver.DeleteHashMapFieldsRequest) (res *kvdbserver.DeleteHashMapFieldsResponse, err error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
 	logPrefix := "DeleteHashMapFields"
 	dbName := s.getDatabaseNameFromContext(ctx)
 
@@ -249,9 +252,6 @@ func (s *Server) DeleteHashMapFields(ctx context.Context, req *kvdbserver.Delete
 		}
 	}()
 
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
-
 	if !s.databaseExists(dbName) {
 		return nil, status.Error(codes.NotFound, kvdberrors.ErrDatabaseNotFound.Error())
 	}
@@ -263,6 +263,9 @@ func (s *Server) DeleteHashMapFields(ctx context.Context, req *kvdbserver.Delete
 
 // GetAllHashMapFieldsAndValues is the implementation of RPC GetAllHashMapFieldsAndValues.
 func (s *Server) GetAllHashMapFieldsAndValues(ctx context.Context, req *kvdbserver.GetAllHashMapFieldsAndValuesRequest) (res *kvdbserver.GetAllHashMapFieldsAndValuesResponse, err error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
 	logPrefix := "GetAllHashMapFieldsAndValues"
 	dbName := s.getDatabaseNameFromContext(ctx)
 
@@ -274,9 +277,6 @@ func (s *Server) GetAllHashMapFieldsAndValues(ctx context.Context, req *kvdbserv
 			s.logger.Debugf("%s: (success) %v", logPrefix, req)
 		}
 	}()
-
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
 
 	if !s.databaseExists(dbName) {
 		return nil, status.Error(codes.NotFound, kvdberrors.ErrDatabaseNotFound.Error())

--- a/cmd/kvdbserver/server/storage_test.go
+++ b/cmd/kvdbserver/server/storage_test.go
@@ -15,6 +15,30 @@ import (
 )
 
 func TestGetTypeOfKey(t *testing.T) {
+	t.Run("MetadataNotSent", func(t *testing.T) {
+		server := server.NewServer()
+		server.DisableLogger()
+		server.CreateDefaultDatabase("default")
+
+		req := &kvdbserver.GetTypeOfKeyRequest{Key: "key1"}
+		res, err := server.GetTypeOfKey(context.Background(), req)
+		require.NoErrorf(t, err, "expected no error; error = %v", err)
+		require.NotNil(t, res)
+	})
+
+	t.Run("DatabaseNotInMetadata", func(t *testing.T) {
+		server := server.NewServer()
+		server.DisableLogger()
+		dbName := "default"
+		server.CreateDefaultDatabase(dbName)
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("wrong-key", dbName))
+
+		req := &kvdbserver.GetTypeOfKeyRequest{Key: "key1"}
+		res, err := server.GetTypeOfKey(ctx, req)
+		require.NoErrorf(t, err, "expected no error; error = %v", err)
+		require.NotNil(t, res)
+	})
+
 	t.Run("DatabaseNotFound", func(t *testing.T) {
 		server := server.NewServer()
 		server.DisableLogger()
@@ -93,6 +117,30 @@ func TestGetTypeOfKey(t *testing.T) {
 }
 
 func TestSetString(t *testing.T) {
+	t.Run("MetadataNotSent", func(t *testing.T) {
+		server := server.NewServer()
+		server.DisableLogger()
+		server.CreateDefaultDatabase("default")
+
+		req := &kvdbserver.SetStringRequest{Key: "key1", Value: "value1"}
+		res, err := server.SetString(context.Background(), req)
+		require.NoErrorf(t, err, "expected no error; error = %v", err)
+		require.NotNil(t, res)
+	})
+
+	t.Run("DatabaseNotInMetadata", func(t *testing.T) {
+		server := server.NewServer()
+		server.DisableLogger()
+		dbName := "default"
+		server.CreateDefaultDatabase(dbName)
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("wrong-key", dbName))
+
+		req := &kvdbserver.SetStringRequest{Key: "key1", Value: "value1"}
+		res, err := server.SetString(ctx, req)
+		require.NoErrorf(t, err, "expected no error; error = %v", err)
+		require.NotNil(t, res)
+	})
+
 	t.Run("DatabaseNotFound", func(t *testing.T) {
 		server := server.NewServer()
 		server.DisableLogger()
@@ -174,6 +222,30 @@ func TestSetString(t *testing.T) {
 }
 
 func TestGetString(t *testing.T) {
+	t.Run("MetadataNotSent", func(t *testing.T) {
+		server := server.NewServer()
+		server.DisableLogger()
+		server.CreateDefaultDatabase("default")
+
+		req := &kvdbserver.GetStringRequest{Key: "key1"}
+		res, err := server.GetString(context.Background(), req)
+		require.NoErrorf(t, err, "expected no error; error = %v", err)
+		require.NotNil(t, res)
+	})
+
+	t.Run("DatabaseNotInMetadata", func(t *testing.T) {
+		server := server.NewServer()
+		server.DisableLogger()
+		dbName := "default"
+		server.CreateDefaultDatabase(dbName)
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("wrong-key", dbName))
+
+		req := &kvdbserver.GetStringRequest{Key: "key1"}
+		res, err := server.GetString(ctx, req)
+		require.NoErrorf(t, err, "expected no error; error = %v", err)
+		require.NotNil(t, res)
+	})
+
 	t.Run("DatabaseNotFound", func(t *testing.T) {
 		server := server.NewServer()
 		server.DisableLogger()
@@ -234,6 +306,30 @@ func TestGetString(t *testing.T) {
 }
 
 func TestDeleteKey(t *testing.T) {
+	t.Run("MetadataNotSent", func(t *testing.T) {
+		server := server.NewServer()
+		server.DisableLogger()
+		server.CreateDefaultDatabase("default")
+
+		req := &kvdbserver.DeleteKeyRequest{Key: "key1"}
+		res, err := server.DeleteKey(context.Background(), req)
+		require.NoErrorf(t, err, "expected no error; error = %v", err)
+		require.NotNil(t, res)
+	})
+
+	t.Run("DatabaseNotInMetadata", func(t *testing.T) {
+		server := server.NewServer()
+		server.DisableLogger()
+		dbName := "default"
+		server.CreateDefaultDatabase(dbName)
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("wrong-key", dbName))
+
+		req := &kvdbserver.DeleteKeyRequest{Key: "key1"}
+		res, err := server.DeleteKey(ctx, req)
+		require.NoErrorf(t, err, "expected no error; error = %v", err)
+		require.NotNil(t, res)
+	})
+
 	t.Run("DatabaseNotFound", func(t *testing.T) {
 		server := server.NewServer()
 		server.DisableLogger()
@@ -293,6 +389,30 @@ func TestDeleteKey(t *testing.T) {
 }
 
 func TestDeleteAllKeys(t *testing.T) {
+	t.Run("MetadataNotSent", func(t *testing.T) {
+		server := server.NewServer()
+		server.DisableLogger()
+		server.CreateDefaultDatabase("default")
+
+		req := &kvdbserver.DeleteAllKeysRequest{}
+		res, err := server.DeleteAllKeys(context.Background(), req)
+		require.NoErrorf(t, err, "expected no error; error = %v", err)
+		require.NotNil(t, res)
+	})
+
+	t.Run("DatabaseNotInMetadata", func(t *testing.T) {
+		server := server.NewServer()
+		server.DisableLogger()
+		dbName := "default"
+		server.CreateDefaultDatabase(dbName)
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("wrong-key", dbName))
+
+		req := &kvdbserver.DeleteAllKeysRequest{}
+		res, err := server.DeleteAllKeys(ctx, req)
+		require.NoErrorf(t, err, "expected no error; error = %v", err)
+		require.NotNil(t, res)
+	})
+
 	t.Run("DatabaseNotFound", func(t *testing.T) {
 		server := server.NewServer()
 		server.DisableLogger()
@@ -345,6 +465,30 @@ func TestDeleteAllKeys(t *testing.T) {
 }
 
 func TestGetKeys(t *testing.T) {
+	t.Run("MetadataNotSent", func(t *testing.T) {
+		server := server.NewServer()
+		server.DisableLogger()
+		server.CreateDefaultDatabase("default")
+
+		req := &kvdbserver.GetKeysRequest{}
+		res, err := server.GetKeys(context.Background(), req)
+		require.NoErrorf(t, err, "expected no error; error = %v", err)
+		require.NotNil(t, res)
+	})
+
+	t.Run("DatabaseNotInMetadata", func(t *testing.T) {
+		server := server.NewServer()
+		server.DisableLogger()
+		dbName := "default"
+		server.CreateDefaultDatabase(dbName)
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("wrong-key", dbName))
+
+		req := &kvdbserver.GetKeysRequest{}
+		res, err := server.GetKeys(ctx, req)
+		require.NoErrorf(t, err, "expected no error; error = %v", err)
+		require.NotNil(t, res)
+	})
+
 	t.Run("DatabaseNotFound", func(t *testing.T) {
 		server := server.NewServer()
 		server.DisableLogger()
@@ -412,6 +556,30 @@ func TestSetHashMap(t *testing.T) {
 	fields["field1"] = "value1"
 	fields["field2"] = "value2"
 	fields["field3"] = "value3"
+
+	t.Run("MetadataNotSent", func(t *testing.T) {
+		server := server.NewServer()
+		server.DisableLogger()
+		server.CreateDefaultDatabase("default")
+
+		req := &kvdbserver.SetHashMapRequest{Key: "key1", Fields: fields}
+		res, err := server.SetHashMap(context.Background(), req)
+		require.NoErrorf(t, err, "expected no error; error = %v", err)
+		require.NotNil(t, res)
+	})
+
+	t.Run("DatabaseNotInMetadata", func(t *testing.T) {
+		server := server.NewServer()
+		server.DisableLogger()
+		dbName := "default"
+		server.CreateDefaultDatabase(dbName)
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("wrong-key", dbName))
+
+		req := &kvdbserver.SetHashMapRequest{Key: "key1", Fields: fields}
+		res, err := server.SetHashMap(ctx, req)
+		require.NoErrorf(t, err, "expected no error; error = %v", err)
+		require.NotNil(t, res)
+	})
 
 	t.Run("DatabaseNotFound", func(t *testing.T) {
 		server := server.NewServer()
@@ -554,6 +722,30 @@ func TestGetHashMapFieldValue(t *testing.T) {
 	fields["field2"] = "value2"
 	fields["field3"] = "value3"
 
+	t.Run("MetadataNotSent", func(t *testing.T) {
+		server := server.NewServer()
+		server.DisableLogger()
+		server.CreateDefaultDatabase("default")
+
+		req := &kvdbserver.GetHashMapFieldValueRequest{Key: "key1", Field: "field2"}
+		res, err := server.GetHashMapFieldValue(context.Background(), req)
+		require.NoErrorf(t, err, "expected no error; error = %v", err)
+		require.NotNil(t, res)
+	})
+
+	t.Run("DatabaseNotInMetadata", func(t *testing.T) {
+		server := server.NewServer()
+		server.DisableLogger()
+		dbName := "default"
+		server.CreateDefaultDatabase(dbName)
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("wrong-key", dbName))
+
+		req := &kvdbserver.GetHashMapFieldValueRequest{Key: "key1", Field: "field2"}
+		res, err := server.GetHashMapFieldValue(ctx, req)
+		require.NoErrorf(t, err, "expected no error; error = %v", err)
+		require.NotNil(t, res)
+	})
+
 	t.Run("DatabaseNotFound", func(t *testing.T) {
 		server := server.NewServer()
 		server.DisableLogger()
@@ -637,6 +829,30 @@ func TestDeleteHashMapFields(t *testing.T) {
 	fields["field2"] = "value2"
 	fields["field3"] = "value3"
 	fieldsToRemove := []string{"field2", "field3"}
+
+	t.Run("MetadataNotSent", func(t *testing.T) {
+		server := server.NewServer()
+		server.DisableLogger()
+		server.CreateDefaultDatabase("default")
+
+		req := &kvdbserver.DeleteHashMapFieldsRequest{Key: "key1", Fields: fieldsToRemove}
+		res, err := server.DeleteHashMapFields(context.Background(), req)
+		require.NoErrorf(t, err, "expected no error; error = %v", err)
+		require.NotNil(t, res)
+	})
+
+	t.Run("DatabaseNotInMetadata", func(t *testing.T) {
+		server := server.NewServer()
+		server.DisableLogger()
+		dbName := "default"
+		server.CreateDefaultDatabase(dbName)
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("wrong-key", dbName))
+
+		req := &kvdbserver.DeleteHashMapFieldsRequest{Key: "key1", Fields: fieldsToRemove}
+		res, err := server.DeleteHashMapFields(ctx, req)
+		require.NoErrorf(t, err, "expected no error; error = %v", err)
+		require.NotNil(t, res)
+	})
 
 	t.Run("DatabaseNotFound", func(t *testing.T) {
 		server := server.NewServer()

--- a/cmd/kvdbserver/server/storage_test.go
+++ b/cmd/kvdbserver/server/storage_test.go
@@ -741,6 +741,30 @@ func TestGetAllHashMapFieldsAndValues(t *testing.T) {
 	fields["field2"] = "value2"
 	fields["field3"] = "value3"
 
+	t.Run("MetadataNotSent", func(t *testing.T) {
+		server := server.NewServer()
+		server.DisableLogger()
+		server.CreateDefaultDatabase("default")
+
+		req := &kvdbserver.GetAllHashMapFieldsAndValuesRequest{Key: "key1"}
+		res, err := server.GetAllHashMapFieldsAndValues(context.Background(), req)
+		require.NoErrorf(t, err, "expected no error; error = %v", err)
+		require.NotNil(t, res)
+	})
+
+	t.Run("DatabaseNotInMetadata", func(t *testing.T) {
+		server := server.NewServer()
+		server.DisableLogger()
+		dbName := "default"
+		server.CreateDefaultDatabase(dbName)
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("wrong-key", dbName))
+
+		req := &kvdbserver.GetAllHashMapFieldsAndValuesRequest{Key: "key1"}
+		res, err := server.GetAllHashMapFieldsAndValues(ctx, req)
+		require.NoErrorf(t, err, "expected no error; error = %v", err)
+		require.NotNil(t, res)
+	})
+
 	t.Run("DatabaseNotFound", func(t *testing.T) {
 		server := server.NewServer()
 		server.DisableLogger()

--- a/cmd/kvdbserver/server/storage_test.go
+++ b/cmd/kvdbserver/server/storage_test.go
@@ -15,42 +15,6 @@ import (
 )
 
 func TestGetTypeOfKey(t *testing.T) {
-	t.Run("MissingMetadata", func(t *testing.T) {
-		server := server.NewServer()
-		server.DisableLogger()
-
-		req := &kvdbserver.GetTypeOfKeyRequest{Key: "key1"}
-		res, err := server.GetTypeOfKey(context.Background(), req)
-		require.Error(t, err)
-		require.Nil(t, res)
-
-		expectedOk := true
-		expectedCode := codes.InvalidArgument
-		st, ok := status.FromError(err)
-		require.NotNil(t, st, "expected status to be non-nil")
-		require.Equalf(t, expectedOk, ok, "expected ok = %v; got = %v", expectedOk, ok)
-		assert.Equal(t, expectedCode, st.Code(), "expected status = %s; got = %s", expectedCode, st.Code())
-	})
-
-	t.Run("MissingDatabaseInMetadata", func(t *testing.T) {
-		server := server.NewServer()
-		server.DisableLogger()
-		dbName := "db0"
-		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("wrong-key", dbName))
-
-		req := &kvdbserver.GetTypeOfKeyRequest{Key: "key1"}
-		res, err := server.GetTypeOfKey(ctx, req)
-		require.Error(t, err)
-		require.Nil(t, res)
-
-		expectedOk := true
-		expectedCode := codes.InvalidArgument
-		st, ok := status.FromError(err)
-		require.NotNil(t, st, "expected status to be non-nil")
-		require.Equalf(t, expectedOk, ok, "expected ok = %v; got = %v", expectedOk, ok)
-		assert.Equal(t, expectedCode, st.Code(), "expected status = %s; got = %s", expectedCode, st.Code())
-	})
-
 	t.Run("DatabaseNotFound", func(t *testing.T) {
 		server := server.NewServer()
 		server.DisableLogger()
@@ -129,39 +93,6 @@ func TestGetTypeOfKey(t *testing.T) {
 }
 
 func TestSetString(t *testing.T) {
-	t.Run("MissingMetadata", func(t *testing.T) {
-		server := server.NewServer()
-		server.DisableLogger()
-
-		request := &kvdbserver.SetStringRequest{Key: "key1", Value: "value1"}
-		response, err := server.SetString(context.Background(), request)
-		require.Error(t, err, "expected error")
-		require.Nil(t, response, "expected response to be nil")
-
-		st, ok := status.FromError(err)
-		require.NotNil(t, st, "expected status to be non-nil")
-		require.Equal(t, true, ok, "expected ok")
-		assert.Equal(t, codes.InvalidArgument, st.Code(), "expected status = %s; got = %s", codes.InvalidArgument, st.Code())
-	})
-
-	t.Run("MissingDatabaseInMetadata", func(t *testing.T) {
-		server := server.NewServer()
-		server.DisableLogger()
-		dbName := "db0"
-		ctxMd := metadata.NewIncomingContext(context.Background(), metadata.Pairs("wrong-key", dbName))
-
-		request := &kvdbserver.SetStringRequest{Key: "key1", Value: "value1"}
-		response, err := server.SetString(ctxMd, request)
-		require.Error(t, err, "expected error")
-		require.Nil(t, response, "expected response to be nil")
-
-		st, ok := status.FromError(err)
-		require.NotNil(t, st, "expected status to be non-nil")
-		require.Equal(t, true, ok, "expected ok")
-		assert.Equal(t, codes.InvalidArgument, st.Code(), "expected status = %s; got = %s", codes.InvalidArgument, st.Code())
-
-	})
-
 	t.Run("DatabaseNotFound", func(t *testing.T) {
 		server := server.NewServer()
 		server.DisableLogger()
@@ -243,38 +174,6 @@ func TestSetString(t *testing.T) {
 }
 
 func TestGetString(t *testing.T) {
-	t.Run("MissingMetadata", func(t *testing.T) {
-		server := server.NewServer()
-		server.DisableLogger()
-
-		request := &kvdbserver.GetStringRequest{Key: "key1"}
-		response, err := server.GetString(context.Background(), request)
-		require.Error(t, err, "expected error")
-		require.Nil(t, response, "expected response to be nil")
-
-		st, ok := status.FromError(err)
-		require.NotNil(t, st, "expected status to be non-nil")
-		require.Equal(t, true, ok, "expected ok")
-		assert.Equal(t, codes.InvalidArgument, st.Code(), "expected status = %s; got = %s", codes.InvalidArgument, st.Code())
-	})
-
-	t.Run("MissingDatabaseInMetadata", func(t *testing.T) {
-		server := server.NewServer()
-		server.DisableLogger()
-		dbName := "db0"
-		ctxMd := metadata.NewIncomingContext(context.Background(), metadata.Pairs("wrong-key", dbName))
-
-		request := &kvdbserver.GetStringRequest{Key: "key1"}
-		response, err := server.GetString(ctxMd, request)
-		require.Error(t, err, "expected error")
-		require.Nil(t, response, "expected response to be nil")
-
-		st, ok := status.FromError(err)
-		require.NotNil(t, st, "expected status to be non-nil")
-		require.Equal(t, true, ok, "expected ok")
-		assert.Equal(t, codes.InvalidArgument, st.Code(), "expected status = %s; got = %s", codes.InvalidArgument, st.Code())
-	})
-
 	t.Run("DatabaseNotFound", func(t *testing.T) {
 		server := server.NewServer()
 		server.DisableLogger()
@@ -335,38 +234,6 @@ func TestGetString(t *testing.T) {
 }
 
 func TestDeleteKey(t *testing.T) {
-	t.Run("MissingMetadata", func(t *testing.T) {
-		server := server.NewServer()
-		server.DisableLogger()
-
-		request := &kvdbserver.DeleteKeyRequest{Key: "key1"}
-		response, err := server.DeleteKey(context.Background(), request)
-		require.Error(t, err, "expected error")
-		require.Nil(t, response, "expected response to be nil")
-
-		st, ok := status.FromError(err)
-		require.NotNil(t, st, "expected status to be non-nil")
-		require.Equal(t, true, ok, "expected ok")
-		assert.Equal(t, codes.InvalidArgument, st.Code(), "expected status = %s; got = %s", codes.InvalidArgument, st.Code())
-	})
-
-	t.Run("MissingDatabaseInMetadata", func(t *testing.T) {
-		server := server.NewServer()
-		server.DisableLogger()
-		dbName := "db0"
-		ctxMd := metadata.NewIncomingContext(context.Background(), metadata.Pairs("wrong-key", dbName))
-
-		request := &kvdbserver.DeleteKeyRequest{Key: "key1"}
-		response, err := server.DeleteKey(ctxMd, request)
-		require.Error(t, err, "expected error")
-		require.Nil(t, response, "expected response to be nil")
-
-		st, ok := status.FromError(err)
-		require.NotNil(t, st, "expected status to be non-nil")
-		require.Equal(t, true, ok, "expected ok")
-		assert.Equal(t, codes.InvalidArgument, st.Code(), "expected status = %s; got = %s", codes.InvalidArgument, st.Code())
-	})
-
 	t.Run("DatabaseNotFound", func(t *testing.T) {
 		server := server.NewServer()
 		server.DisableLogger()
@@ -426,38 +293,6 @@ func TestDeleteKey(t *testing.T) {
 }
 
 func TestDeleteAllKeys(t *testing.T) {
-	t.Run("MissingMetadata", func(t *testing.T) {
-		server := server.NewServer()
-		server.DisableLogger()
-
-		req := &kvdbserver.DeleteAllKeysRequest{}
-		res, err := server.DeleteAllKeys(context.Background(), req)
-		require.Error(t, err)
-		require.Nil(t, res)
-
-		st, ok := status.FromError(err)
-		require.NotNil(t, st)
-		require.Equal(t, true, ok, "expected ok")
-		assert.Equal(t, codes.InvalidArgument, st.Code(), "expected status = %s; got = %s", codes.InvalidArgument, st.Code())
-	})
-
-	t.Run("MissingDatabaseInMetadata", func(t *testing.T) {
-		server := server.NewServer()
-		server.DisableLogger()
-		dbName := "db0"
-		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("wrong-key", dbName))
-
-		req := &kvdbserver.DeleteAllKeysRequest{}
-		res, err := server.DeleteAllKeys(ctx, req)
-		require.Error(t, err)
-		require.Nil(t, res)
-
-		st, ok := status.FromError(err)
-		require.NotNil(t, st)
-		require.Equal(t, true, ok, "expected ok")
-		assert.Equal(t, codes.InvalidArgument, st.Code(), "expected status = %s; got = %s", codes.InvalidArgument, st.Code())
-	})
-
 	t.Run("DatabaseNotFound", func(t *testing.T) {
 		server := server.NewServer()
 		server.DisableLogger()
@@ -510,38 +345,6 @@ func TestDeleteAllKeys(t *testing.T) {
 }
 
 func TestGetKeys(t *testing.T) {
-	t.Run("MissingMetadata", func(t *testing.T) {
-		server := server.NewServer()
-		server.DisableLogger()
-
-		req := &kvdbserver.GetKeysRequest{}
-		res, err := server.GetKeys(context.Background(), req)
-		require.Error(t, err)
-		require.Nil(t, res)
-
-		st, ok := status.FromError(err)
-		require.NotNil(t, st)
-		require.Equal(t, true, ok, "expected ok")
-		assert.Equal(t, codes.InvalidArgument, st.Code(), "expected status = %s; got = %s", codes.InvalidArgument, st.Code())
-	})
-
-	t.Run("MissingDatabaseInMetadata", func(t *testing.T) {
-		server := server.NewServer()
-		server.DisableLogger()
-		dbName := "db0"
-		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("wrong-key", dbName))
-
-		req := &kvdbserver.GetKeysRequest{}
-		res, err := server.GetKeys(ctx, req)
-		require.Error(t, err)
-		require.Nil(t, res)
-
-		st, ok := status.FromError(err)
-		require.NotNil(t, st)
-		require.Equal(t, true, ok, "expected ok")
-		assert.Equal(t, codes.InvalidArgument, st.Code(), "expected status = %s; got = %s", codes.InvalidArgument, st.Code())
-	})
-
 	t.Run("DatabaseNotFound", func(t *testing.T) {
 		server := server.NewServer()
 		server.DisableLogger()
@@ -609,42 +412,6 @@ func TestSetHashMap(t *testing.T) {
 	fields["field1"] = "value1"
 	fields["field2"] = "value2"
 	fields["field3"] = "value3"
-
-	t.Run("MissingMetadata", func(t *testing.T) {
-		server := server.NewServer()
-		server.DisableLogger()
-
-		req := &kvdbserver.SetHashMapRequest{Key: "key1", Fields: fields}
-		res, err := server.SetHashMap(context.Background(), req)
-		require.Error(t, err)
-		require.Nil(t, res)
-
-		expectedOk := true
-		expectedCode := codes.InvalidArgument
-		st, ok := status.FromError(err)
-		require.NotNil(t, st, "expected status to be non-nil")
-		require.Equalf(t, expectedOk, ok, "expected ok = %v; got = %v", expectedOk, ok)
-		assert.Equal(t, expectedCode, st.Code(), "expected status = %s; got = %s", expectedCode, st.Code())
-	})
-
-	t.Run("MissingDatabaseInMetadata", func(t *testing.T) {
-		server := server.NewServer()
-		server.DisableLogger()
-		dbName := "db0"
-		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("wrong-key", dbName))
-
-		req := &kvdbserver.SetHashMapRequest{Key: "key1", Fields: fields}
-		res, err := server.SetHashMap(ctx, req)
-		require.Error(t, err)
-		require.Nil(t, res)
-
-		expectedOk := true
-		expectedCode := codes.InvalidArgument
-		st, ok := status.FromError(err)
-		require.NotNil(t, st, "expected status to be non-nil")
-		require.Equalf(t, expectedOk, ok, "expected ok = %v; got = %v", expectedOk, ok)
-		assert.Equal(t, expectedCode, st.Code(), "expected status = %s; got = %s", expectedCode, st.Code())
-	})
 
 	t.Run("DatabaseNotFound", func(t *testing.T) {
 		server := server.NewServer()
@@ -787,42 +554,6 @@ func TestGetHashMapFieldValue(t *testing.T) {
 	fields["field2"] = "value2"
 	fields["field3"] = "value3"
 
-	t.Run("MissingMetadata", func(t *testing.T) {
-		server := server.NewServer()
-		server.DisableLogger()
-
-		req := &kvdbserver.GetHashMapFieldValueRequest{Key: "key1", Field: "field2"}
-		res, err := server.GetHashMapFieldValue(context.Background(), req)
-		require.Error(t, err)
-		require.Nil(t, res)
-
-		expectedOk := true
-		expectedCode := codes.InvalidArgument
-		st, ok := status.FromError(err)
-		require.NotNil(t, st, "expected status to be non-nil")
-		require.Equalf(t, expectedOk, ok, "expected ok = %v; got = %v", expectedOk, ok)
-		assert.Equal(t, expectedCode, st.Code(), "expected status = %s; got = %s", expectedCode, st.Code())
-	})
-
-	t.Run("MissingDatabaseInMetadata", func(t *testing.T) {
-		server := server.NewServer()
-		server.DisableLogger()
-		dbName := "db0"
-		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("wrong-key", dbName))
-
-		req := &kvdbserver.GetHashMapFieldValueRequest{Key: "key1", Field: "field2"}
-		res, err := server.GetHashMapFieldValue(ctx, req)
-		require.Error(t, err)
-		require.Nil(t, res)
-
-		expectedOk := true
-		expectedCode := codes.InvalidArgument
-		st, ok := status.FromError(err)
-		require.NotNil(t, st, "expected status to be non-nil")
-		require.Equalf(t, expectedOk, ok, "expected ok = %v; got = %v", expectedOk, ok)
-		assert.Equal(t, expectedCode, st.Code(), "expected status = %s; got = %s", expectedCode, st.Code())
-	})
-
 	t.Run("DatabaseNotFound", func(t *testing.T) {
 		server := server.NewServer()
 		server.DisableLogger()
@@ -906,42 +637,6 @@ func TestDeleteHashMapFields(t *testing.T) {
 	fields["field2"] = "value2"
 	fields["field3"] = "value3"
 	fieldsToRemove := []string{"field2", "field3"}
-
-	t.Run("MissingMetadata", func(t *testing.T) {
-		server := server.NewServer()
-		server.DisableLogger()
-
-		req := &kvdbserver.DeleteHashMapFieldsRequest{Key: "key1", Fields: fieldsToRemove}
-		res, err := server.DeleteHashMapFields(context.Background(), req)
-		require.Error(t, err)
-		require.Nil(t, res)
-
-		expectedOk := true
-		expectedCode := codes.InvalidArgument
-		st, ok := status.FromError(err)
-		require.NotNil(t, st, "expected status to be non-nil")
-		require.Equalf(t, expectedOk, ok, "expected ok = %v; got = %v", expectedOk, ok)
-		assert.Equal(t, expectedCode, st.Code(), "expected status = %s; got = %s", expectedCode, st.Code())
-	})
-
-	t.Run("MissingDatabaseInMetadata", func(t *testing.T) {
-		server := server.NewServer()
-		server.DisableLogger()
-		dbName := "db0"
-		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("wrong-key", dbName))
-
-		req := &kvdbserver.DeleteHashMapFieldsRequest{Key: "key1", Fields: fieldsToRemove}
-		res, err := server.DeleteHashMapFields(ctx, req)
-		require.Error(t, err)
-		require.Nil(t, res)
-
-		expectedOk := true
-		expectedCode := codes.InvalidArgument
-		st, ok := status.FromError(err)
-		require.NotNil(t, st, "expected status to be non-nil")
-		require.Equalf(t, expectedOk, ok, "expected ok = %v; got = %v", expectedOk, ok)
-		assert.Equal(t, expectedCode, st.Code(), "expected status = %s; got = %s", expectedCode, st.Code())
-	})
 
 	t.Run("DatabaseNotFound", func(t *testing.T) {
 		server := server.NewServer()
@@ -1045,42 +740,6 @@ func TestGetAllHashMapFieldsAndValues(t *testing.T) {
 	fields["field1"] = "value1"
 	fields["field2"] = "value2"
 	fields["field3"] = "value3"
-
-	t.Run("MissingMetadata", func(t *testing.T) {
-		server := server.NewServer()
-		server.DisableLogger()
-
-		req := &kvdbserver.GetAllHashMapFieldsAndValuesRequest{Key: "key1"}
-		res, err := server.GetAllHashMapFieldsAndValues(context.Background(), req)
-		require.Error(t, err)
-		require.Nil(t, res)
-
-		expectedOk := true
-		expectedCode := codes.InvalidArgument
-		st, ok := status.FromError(err)
-		require.NotNil(t, st, "expected status to be non-nil")
-		require.Equalf(t, expectedOk, ok, "expected ok = %v; got = %v", expectedOk, ok)
-		assert.Equal(t, expectedCode, st.Code(), "expected status = %s; got = %s", expectedCode, st.Code())
-	})
-
-	t.Run("MissingDatabaseInMetadata", func(t *testing.T) {
-		server := server.NewServer()
-		server.DisableLogger()
-		dbName := "db0"
-		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("wrong-key", dbName))
-
-		req := &kvdbserver.GetAllHashMapFieldsAndValuesRequest{Key: "key1"}
-		res, err := server.GetAllHashMapFieldsAndValues(ctx, req)
-		require.Error(t, err)
-		require.Nil(t, res)
-
-		expectedOk := true
-		expectedCode := codes.InvalidArgument
-		st, ok := status.FromError(err)
-		require.NotNil(t, st, "expected status to be non-nil")
-		require.Equalf(t, expectedOk, ok, "expected ok = %v; got = %v", expectedOk, ok)
-		assert.Equal(t, expectedCode, st.Code(), "expected status = %s; got = %s", expectedCode, st.Code())
-	})
 
 	t.Run("DatabaseNotFound", func(t *testing.T) {
 		server := server.NewServer()

--- a/docs/api.md
+++ b/docs/api.md
@@ -48,7 +48,7 @@ The storage service `StorageService` is defined in the `storage.proto` file. Thi
 
 Common gRPC metadata for this service's RPCs:
 - `password`: The server password if the server is password protected.
-- `database-name`: The database to use. Required.
+- `database`: The database to use. Required.
 
 RPCs:
 - GetTypeOfKey

--- a/internal/common/grpc.go
+++ b/internal/common/grpc.go
@@ -1,8 +1,8 @@
 package common
 
 const (
-	// GrpcMetadataKeyDbName represents the gRPC metadata key for database name.
-	GrpcMetadataKeyDbName string = "database-name"
+	// GrpcMetadataKeyDbName represents the gRPC metadata key for database.
+	GrpcMetadataKeyDbName string = "database"
 	// GrpcMetadataKeyPassword represents the gRPC metadata key for password.
 	GrpcMetadataKeyPassword string = "password"
 )

--- a/proto/kvdbserver/storage.proto
+++ b/proto/kvdbserver/storage.proto
@@ -114,7 +114,7 @@ message GetAllHashMapFieldsAndValuesResponse {
 //
 // Common gRPC metadata for this service's RPCs:
 // - password: The server password if the server is password protected.
-// - database-name: The database to use. Required.
+// - database: The database to use. Required.
 service StorageService {
     // GetTypeOfKey returns the data type of a key.
     rpc GetTypeOfKey(GetTypeOfKeyRequest) returns (GetTypeOfKeyResponse) {}

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -35,6 +35,8 @@ func setupServer() *grpc.Server {
 	viper.SetEnvPrefix(kvdbs.EnvPrefix)
 	viper.AutomaticEnv()
 
+	server.SetPort(viper.GetUint16("port"))
+
 	grpcServer := grpc.NewServer()
 	kvdbserver.RegisterDatabaseServiceServer(grpcServer, server)
 	kvdbserver.RegisterServerServiceServer(grpcServer, server)


### PR DESCRIPTION
- Changed 'database-name' gRPC metadata to 'database'
- Changed the server to use the default database if database is not sent in metadata
- database name is now included in storage debug logs
- Refactored server
- Updated tests