### PR TITLE
Refactor db key count

### DIFF
--- a/cmd/kvdbserver/server/api.go
+++ b/cmd/kvdbserver/server/api.go
@@ -180,7 +180,7 @@ func (s *KvdbServer) GetDBInfo(ctx context.Context, req *dbpb.GetDBInfoRequest) 
 		Name:      db.Name(),
 		CreatedAt: timestamppb.New(db.CreatedAt()),
 		UpdatedAt: timestamppb.New(db.UpdatedAt()),
-		KeyCount:  db.GetKeyCount(),
+		KeyCount:  uint32(db.GetKeyCount()),
 		DataSize:  db.GetEstimatedStorageSizeBytes(),
 	}
 

--- a/cmd/kvdbserver/server/server.go
+++ b/cmd/kvdbserver/server/server.go
@@ -208,7 +208,7 @@ func (s *KvdbServer) CreateDefaultDatabase(name string) {
 
 // DBMaxKeysReached returns true if a database has reached or exceeded the maximum key limit.
 func (s *KvdbServer) DBMaxKeysReached(db *kvdb.DB) bool {
-	return db.GetKeyCount() >= s.Cfg.MaxKeysPerDB
+	return uint32(db.GetKeyCount()) >= s.Cfg.MaxKeysPerDB
 }
 
 // Init initializes the server.

--- a/db_test.go
+++ b/db_test.go
@@ -70,7 +70,7 @@ func TestSetString(t *testing.T) {
 		db := NewDB("test", "", dbCfg)
 		db.SetString("key1", []byte("value1"))
 
-		var expectedKeys uint32 = 1
+		var expectedKeys = 1
 		keys := db.GetKeyCount()
 		if keys != expectedKeys {
 			t.Errorf("expected keys = %d; got = %d", expectedKeys, keys)
@@ -82,7 +82,7 @@ func TestSetString(t *testing.T) {
 		db.SetString("key1", []byte("value1"))
 		db.SetString("key1", []byte("value2"))
 
-		var expectedKeys uint32 = 1
+		var expectedKeys = 1
 		keys := db.GetKeyCount()
 		if keys != expectedKeys {
 			t.Errorf("expected keys = %d; got = %d", expectedKeys, keys)
@@ -293,6 +293,15 @@ func TestGetKeyCount(t *testing.T) {
 	if count != 0 {
 		t.Fatalf("key count should be 0 but got %d", count)
 	}
+
+	db.SetString("key1", []byte("value1"))
+	db.SetHashMap("key2", map[string][]byte{
+		"field1": []byte("value1"),
+	})
+	count = db.GetKeyCount()
+	if count != 2 {
+		t.Fatalf("key count should be 2 but got %d", count)
+	}
 }
 
 func TestDeleteAllKeys(t *testing.T) {
@@ -318,7 +327,7 @@ func TestDeleteAllKeys(t *testing.T) {
 		}
 
 		count := db.GetKeyCount()
-		var expectedCount uint32 = 3
+		var expectedCount = 3
 		if count != expectedCount {
 			t.Fatalf("expected keys = %d; got = %d", expectedCount, count)
 		}
@@ -384,7 +393,7 @@ func TestSetHashMap(t *testing.T) {
 			t.Errorf("expected fields added = %d; got = %d", expectedFieldsAdded, fieldsAdded)
 		}
 
-		var expectedKeys uint32 = 1
+		var expectedKeys = 1
 		keys := db.GetKeyCount()
 		if keys != expectedKeys {
 			t.Errorf("expected keys = %d; got = %d", expectedKeys, keys)
@@ -401,7 +410,7 @@ func TestSetHashMap(t *testing.T) {
 			t.Errorf("expected fields added = %d; got = %d", expectedFieldsAdded, fieldsAdded)
 		}
 
-		var expectedKeys uint32 = 1
+		var expectedKeys = 1
 		keys := db.GetKeyCount()
 		if keys != expectedKeys {
 			t.Errorf("expected keys = %d; got = %d", expectedKeys, keys)


### PR DESCRIPTION
Database key count is no longer tracked with a struct field. It now uses len() function to get the number of elements in the key maps.