### PR TITLE
Benchmarks for SetString and GetString RPCs

### DIFF
--- a/cmd/kvdbserver/grpc/db/db_test.go
+++ b/cmd/kvdbserver/grpc/db/db_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hollowdll/kvdb"
 	"github.com/hollowdll/kvdb/api/v0/dbpb"
 	"github.com/hollowdll/kvdb/cmd/kvdbserver/config"
 	"github.com/hollowdll/kvdb/cmd/kvdbserver/server"
 	"github.com/hollowdll/kvdb/internal/common"
-	"github.com/hollowdll/kvdb/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -19,7 +19,7 @@ func TestCreateDB(t *testing.T) {
 	cfg := config.DefaultConfig()
 
 	t.Run("DatabaseNotExists", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewDBServiceServer(s)
 		dbName := "test"
 
@@ -32,7 +32,7 @@ func TestCreateDB(t *testing.T) {
 	})
 
 	t.Run("DatabaseAlreadyExists", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewDBServiceServer(s)
 		dbName := "test"
 
@@ -51,7 +51,7 @@ func TestCreateDB(t *testing.T) {
 	})
 
 	t.Run("InvalidDatabaseName", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewDBServiceServer(s)
 		dbName := "   "
 
@@ -71,7 +71,7 @@ func TestGetAllDBs(t *testing.T) {
 	cfg := config.DefaultConfig()
 
 	t.Run("NoDatabases", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewDBServiceServer(s)
 		expected := 0
 		req := &dbpb.GetAllDBsRequest{}
@@ -83,7 +83,7 @@ func TestGetAllDBs(t *testing.T) {
 	})
 
 	t.Run("MultipleDatabases", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewDBServiceServer(s)
 
 		dbs := []string{"db0", "db1", "db2"}
@@ -109,7 +109,7 @@ func TestGetDBInfo(t *testing.T) {
 	cfg := config.DefaultConfig()
 
 	t.Run("DatabaseNotFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewDBServiceServer(s)
 		dbName := "db0"
 
@@ -125,7 +125,7 @@ func TestGetDBInfo(t *testing.T) {
 	})
 
 	t.Run("DatabaseExists", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewDBServiceServer(s)
 		dbName := "db0"
 
@@ -150,7 +150,7 @@ func TestDeleteDB(t *testing.T) {
 	cfg := config.DefaultConfig()
 
 	t.Run("DatabaseExists", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewDBServiceServer(s)
 		dbName := "default"
 		s.CreateDefaultDatabase(dbName)
@@ -164,7 +164,7 @@ func TestDeleteDB(t *testing.T) {
 	})
 
 	t.Run("DatabaseNotFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewDBServiceServer(s)
 		dbName := "default"
 
@@ -184,7 +184,7 @@ func TestDefaultDatabase(t *testing.T) {
 	cfg := config.DefaultConfig()
 
 	t.Run("GetDatabaseInfo", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewDBServiceServer(s)
 		dbName := "default"
 		s.CreateDefaultDatabase(dbName)
@@ -197,7 +197,7 @@ func TestDefaultDatabase(t *testing.T) {
 	})
 
 	t.Run("GetAllDatabases", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewDBServiceServer(s)
 		dbName := "default"
 		s.CreateDefaultDatabase(dbName)

--- a/cmd/kvdbserver/grpc/kv/general_key_test.go
+++ b/cmd/kvdbserver/grpc/kv/general_key_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hollowdll/kvdb"
 	"github.com/hollowdll/kvdb/api/v0/kvpb"
 	"github.com/hollowdll/kvdb/cmd/kvdbserver/config"
 	"github.com/hollowdll/kvdb/cmd/kvdbserver/server"
 	"github.com/hollowdll/kvdb/internal/common"
-	"github.com/hollowdll/kvdb/internal/testutil"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,7 +22,7 @@ func TestGetKeyType(t *testing.T) {
 	cfg.DefaultDB = "default"
 
 	t.Run("DBNotSentInMetadataUseDefaultDB", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewGeneralKVServiceServer(s)
 		s.CreateDefaultDatabase(cfg.DefaultDB)
 
@@ -33,7 +33,7 @@ func TestGetKeyType(t *testing.T) {
 	})
 
 	t.Run("DBNotFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewGeneralKVServiceServer(s)
 		s.CreateDefaultDatabase(cfg.DefaultDB)
 		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(common.GrpcMetadataKeyDbName, "DBNotFound"))
@@ -52,7 +52,7 @@ func TestGetKeyType(t *testing.T) {
 	})
 
 	t.Run("KeyNotFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewGeneralKVServiceServer(s)
 		dbName := "db123"
 		s.CreateDefaultDatabase(dbName)
@@ -69,7 +69,7 @@ func TestGetKeyType(t *testing.T) {
 	})
 
 	t.Run("StringKey", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gsGeneralKV := NewGeneralKVServiceServer(s)
 		gsStringKV := NewStringKVServiceServer(s)
 		dbName := "db123"
@@ -90,7 +90,7 @@ func TestGetKeyType(t *testing.T) {
 	})
 
 	t.Run("HashMapKey", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gsGeneralKV := NewGeneralKVServiceServer(s)
 		gsHashMapKV := NewHashMapKVServiceServer(s)
 		dbName := "db123"
@@ -116,7 +116,7 @@ func TestGetAllKeys(t *testing.T) {
 	cfg.DefaultDB = "default"
 
 	t.Run("DBNotSentInMetadataUseDefaultDB", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewGeneralKVServiceServer(s)
 		s.CreateDefaultDatabase(cfg.DefaultDB)
 
@@ -127,7 +127,7 @@ func TestGetAllKeys(t *testing.T) {
 	})
 
 	t.Run("DBNotFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewGeneralKVServiceServer(s)
 		s.CreateDefaultDatabase(cfg.DefaultDB)
 		dbName := "db123"
@@ -147,7 +147,7 @@ func TestGetAllKeys(t *testing.T) {
 	})
 
 	t.Run("NoKeysPresent", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewGeneralKVServiceServer(s)
 		dbName := "db123"
 		s.CreateDefaultDatabase(dbName)
@@ -162,7 +162,7 @@ func TestGetAllKeys(t *testing.T) {
 	})
 
 	t.Run("KeysPresent", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gsGeneralKV := NewGeneralKVServiceServer(s)
 		gsStringKV := NewStringKVServiceServer(s)
 		dbName := "db123"
@@ -193,7 +193,7 @@ func TestDeleteKeys(t *testing.T) {
 	cfg.DefaultDB = "default"
 
 	t.Run("DBNotSentInMetadataUseDefaultDB", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewGeneralKVServiceServer(s)
 		s.CreateDefaultDatabase(cfg.DefaultDB)
 
@@ -204,7 +204,7 @@ func TestDeleteKeys(t *testing.T) {
 	})
 
 	t.Run("DBNotFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewGeneralKVServiceServer(s)
 		s.CreateDefaultDatabase(cfg.DefaultDB)
 		dbName := "db123"
@@ -224,7 +224,7 @@ func TestDeleteKeys(t *testing.T) {
 	})
 
 	t.Run("KeyNotFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewGeneralKVServiceServer(s)
 		dbName := "db123"
 		s.CreateDefaultDatabase(dbName)
@@ -239,7 +239,7 @@ func TestDeleteKeys(t *testing.T) {
 	})
 
 	t.Run("KeyFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gsGeneralKV := NewGeneralKVServiceServer(s)
 		gsStringKV := NewStringKVServiceServer(s)
 		dbName := "db123"
@@ -264,7 +264,7 @@ func TestDeleteAllKeys(t *testing.T) {
 	cfg.DefaultDB = "default"
 
 	t.Run("DBNotSentInMetadataUseDefaultDB", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewGeneralKVServiceServer(s)
 		s.CreateDefaultDatabase(cfg.DefaultDB)
 
@@ -275,7 +275,7 @@ func TestDeleteAllKeys(t *testing.T) {
 	})
 
 	t.Run("DBNotFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewGeneralKVServiceServer(s)
 		s.CreateDefaultDatabase(cfg.DefaultDB)
 		dbName := "db123"
@@ -293,7 +293,7 @@ func TestDeleteAllKeys(t *testing.T) {
 	})
 
 	t.Run("NoKeysPresent", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewGeneralKVServiceServer(s)
 		dbName := "db0"
 		s.CreateDefaultDatabase(dbName)
@@ -306,7 +306,7 @@ func TestDeleteAllKeys(t *testing.T) {
 	})
 
 	t.Run("KeysPresent", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gsGeneralKV := NewGeneralKVServiceServer(s)
 		gsStringKV := NewStringKVServiceServer(s)
 		dbName := "db0"

--- a/cmd/kvdbserver/grpc/kv/hashmap_key_test.go
+++ b/cmd/kvdbserver/grpc/kv/hashmap_key_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hollowdll/kvdb"
 	"github.com/hollowdll/kvdb/api/v0/kvpb"
 	"github.com/hollowdll/kvdb/cmd/kvdbserver/config"
 	"github.com/hollowdll/kvdb/cmd/kvdbserver/server"
 	"github.com/hollowdll/kvdb/internal/common"
-	"github.com/hollowdll/kvdb/internal/testutil"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,7 +26,7 @@ func TestSetHashMap(t *testing.T) {
 	fields["field3"] = []byte("value3")
 
 	t.Run("DBNotSentInMetadataUseDefaultDB", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewHashMapKVServiceServer(s)
 		s.CreateDefaultDatabase(cfg.DefaultDB)
 
@@ -37,7 +37,7 @@ func TestSetHashMap(t *testing.T) {
 	})
 
 	t.Run("DBNotFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewHashMapKVServiceServer(s)
 		s.CreateDefaultDatabase(cfg.DefaultDB)
 		dbName := "db123"
@@ -57,7 +57,7 @@ func TestSetHashMap(t *testing.T) {
 	})
 
 	t.Run("FieldsAdded", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewHashMapKVServiceServer(s)
 		dbName := "db123"
 		s.CreateDefaultDatabase(dbName)
@@ -73,7 +73,7 @@ func TestSetHashMap(t *testing.T) {
 	})
 
 	t.Run("OverwriteFields", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewHashMapKVServiceServer(s)
 		dbName := "db123"
 		s.CreateDefaultDatabase(dbName)
@@ -101,7 +101,7 @@ func TestSetHashMap(t *testing.T) {
 	})
 
 	t.Run("InvalidKey", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewHashMapKVServiceServer(s)
 		dbName := "db123"
 		s.CreateDefaultDatabase(dbName)
@@ -123,7 +123,7 @@ func TestSetHashMap(t *testing.T) {
 	t.Run("MaxKeyLimitReached", func(t *testing.T) {
 		cfg := cfg
 		cfg.MaxKeysPerDB = 1
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewHashMapKVServiceServer(s)
 		dbName := "db123"
 		s.CreateDefaultDatabase(dbName)
@@ -150,7 +150,7 @@ func TestSetHashMap(t *testing.T) {
 	t.Run("MaxFieldLimitReached", func(t *testing.T) {
 		cfg := cfg
 		cfg.MaxHashMapFields = 4
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewHashMapKVServiceServer(s)
 		dbName := "db123"
 		s.CreateDefaultDatabase(dbName)
@@ -187,7 +187,7 @@ func TestGetHashMapFieldValues(t *testing.T) {
 	fields["field3"] = []byte("value3")
 
 	t.Run("DBNotSentInMetadataUseDefaultDB", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewHashMapKVServiceServer(s)
 		s.CreateDefaultDatabase(cfg.DefaultDB)
 
@@ -198,7 +198,7 @@ func TestGetHashMapFieldValues(t *testing.T) {
 	})
 
 	t.Run("DBNotFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewHashMapKVServiceServer(s)
 		s.CreateDefaultDatabase(cfg.DefaultDB)
 		dbName := "db123"
@@ -218,7 +218,7 @@ func TestGetHashMapFieldValues(t *testing.T) {
 	})
 
 	t.Run("KeyAndFieldFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewHashMapKVServiceServer(s)
 		dbName := "db123"
 		s.CreateDefaultDatabase(dbName)
@@ -240,7 +240,7 @@ func TestGetHashMapFieldValues(t *testing.T) {
 	})
 
 	t.Run("MultipleFieldsFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewHashMapKVServiceServer(s)
 		dbName := "db123"
 		s.CreateDefaultDatabase(dbName)
@@ -261,7 +261,7 @@ func TestGetHashMapFieldValues(t *testing.T) {
 	})
 
 	t.Run("KeyNotFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewHashMapKVServiceServer(s)
 		dbName := "db123"
 		s.CreateDefaultDatabase(dbName)
@@ -276,7 +276,7 @@ func TestGetHashMapFieldValues(t *testing.T) {
 	})
 
 	t.Run("FieldNotFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewHashMapKVServiceServer(s)
 		dbName := "db123"
 		s.CreateDefaultDatabase(dbName)
@@ -306,7 +306,7 @@ func TestDeleteHashMapFields(t *testing.T) {
 	fieldsToRemove := []string{"field2", "field3"}
 
 	t.Run("DBNotSentInMetadataUseDefaultDB", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewHashMapKVServiceServer(s)
 		s.CreateDefaultDatabase(cfg.DefaultDB)
 
@@ -317,7 +317,7 @@ func TestDeleteHashMapFields(t *testing.T) {
 	})
 
 	t.Run("DBNotFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewHashMapKVServiceServer(s)
 		s.CreateDefaultDatabase(cfg.DefaultDB)
 		dbName := "db123"
@@ -337,7 +337,7 @@ func TestDeleteHashMapFields(t *testing.T) {
 	})
 
 	t.Run("KeyNotFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewHashMapKVServiceServer(s)
 		dbName := "db123"
 		s.CreateDefaultDatabase(dbName)
@@ -354,7 +354,7 @@ func TestDeleteHashMapFields(t *testing.T) {
 	})
 
 	t.Run("FieldsNotExist", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewHashMapKVServiceServer(s)
 		dbName := "db123"
 		s.CreateDefaultDatabase(dbName)
@@ -374,7 +374,7 @@ func TestDeleteHashMapFields(t *testing.T) {
 	})
 
 	t.Run("FieldsExist", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewHashMapKVServiceServer(s)
 		dbName := "db123"
 		s.CreateDefaultDatabase(dbName)
@@ -394,7 +394,7 @@ func TestDeleteHashMapFields(t *testing.T) {
 	})
 
 	t.Run("DuplicateFields", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewHashMapKVServiceServer(s)
 		dbName := "db123"
 		s.CreateDefaultDatabase(dbName)
@@ -423,7 +423,7 @@ func TestGetAllHashMapFieldsAndValues(t *testing.T) {
 	fields["field3"] = []byte("value3")
 
 	t.Run("DBNotSentInMetadataUseDefaultDB", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewHashMapKVServiceServer(s)
 		s.CreateDefaultDatabase(cfg.DefaultDB)
 
@@ -434,7 +434,7 @@ func TestGetAllHashMapFieldsAndValues(t *testing.T) {
 	})
 
 	t.Run("DBNotFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewHashMapKVServiceServer(s)
 		s.CreateDefaultDatabase(cfg.DefaultDB)
 		dbName := "db123"
@@ -454,7 +454,7 @@ func TestGetAllHashMapFieldsAndValues(t *testing.T) {
 	})
 
 	t.Run("KeyNotFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewHashMapKVServiceServer(s)
 		dbName := "db123"
 		s.CreateDefaultDatabase(dbName)
@@ -472,7 +472,7 @@ func TestGetAllHashMapFieldsAndValues(t *testing.T) {
 	})
 
 	t.Run("KeyFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewHashMapKVServiceServer(s)
 		dbName := "db123"
 		s.CreateDefaultDatabase(dbName)

--- a/cmd/kvdbserver/grpc/kv/string_key_test.go
+++ b/cmd/kvdbserver/grpc/kv/string_key_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hollowdll/kvdb"
 	"github.com/hollowdll/kvdb/api/v0/kvpb"
 	"github.com/hollowdll/kvdb/cmd/kvdbserver/config"
 	"github.com/hollowdll/kvdb/cmd/kvdbserver/server"
 	"github.com/hollowdll/kvdb/internal/common"
-	"github.com/hollowdll/kvdb/internal/testutil"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,7 +22,7 @@ func TestSetString(t *testing.T) {
 	cfg.DefaultDB = "default"
 
 	t.Run("DBNotSentInMetadataUseDefaultDB", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewStringKVServiceServer(s)
 		s.CreateDefaultDatabase(cfg.DefaultDB)
 
@@ -33,7 +33,7 @@ func TestSetString(t *testing.T) {
 	})
 
 	t.Run("DBNotFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewStringKVServiceServer(s)
 		s.CreateDefaultDatabase(cfg.DefaultDB)
 		dbName := "db123"
@@ -51,7 +51,7 @@ func TestSetString(t *testing.T) {
 	})
 
 	t.Run("Success", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewStringKVServiceServer(s)
 		dbName := "db123"
 		s.CreateDefaultDatabase(dbName)
@@ -64,7 +64,7 @@ func TestSetString(t *testing.T) {
 	})
 
 	t.Run("InvalidKey", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewStringKVServiceServer(s)
 		dbName := "db123"
 		s.CreateDefaultDatabase(dbName)
@@ -84,7 +84,7 @@ func TestSetString(t *testing.T) {
 	t.Run("MaxKeyLimitReached", func(t *testing.T) {
 		cfg := cfg
 		cfg.MaxKeysPerDB = 1
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewStringKVServiceServer(s)
 		dbName := "db123"
 		s.CreateDefaultDatabase(dbName)
@@ -114,7 +114,7 @@ func TestGetString(t *testing.T) {
 	cfg.DefaultDB = "default"
 
 	t.Run("DBNotSentInMetadataUseDefaultDB", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewStringKVServiceServer(s)
 		s.CreateDefaultDatabase(cfg.DefaultDB)
 
@@ -125,7 +125,7 @@ func TestGetString(t *testing.T) {
 	})
 
 	t.Run("DBNotFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewStringKVServiceServer(s)
 		s.CreateDefaultDatabase(cfg.DefaultDB)
 		dbName := "db123"
@@ -143,7 +143,7 @@ func TestGetString(t *testing.T) {
 	})
 
 	t.Run("KeyNotFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewStringKVServiceServer(s)
 		dbName := "db123"
 		s.CreateDefaultDatabase(dbName)
@@ -159,7 +159,7 @@ func TestGetString(t *testing.T) {
 	})
 
 	t.Run("KeyFound", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		gs := NewStringKVServiceServer(s)
 		dbName := "db123"
 		s.CreateDefaultDatabase(dbName)

--- a/cmd/kvdbserver/grpc/server/server_test.go
+++ b/cmd/kvdbserver/grpc/server/server_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hollowdll/kvdb"
 	"github.com/hollowdll/kvdb/api/v0/serverpb"
 	"github.com/hollowdll/kvdb/cmd/kvdbserver/config"
 	"github.com/hollowdll/kvdb/cmd/kvdbserver/server"
 	"github.com/hollowdll/kvdb/internal/common"
-	"github.com/hollowdll/kvdb/internal/testutil"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,7 +20,7 @@ func TestGetServerInfo(t *testing.T) {
 	cfg := config.DefaultConfig()
 
 	t.Run("Success", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		connLis := server.NewClientConnListener(nil, s, cfg.MaxClientConnections)
 		s.ClientConnListener = connLis
 		grpcSrv := NewServerServiceServer(s)
@@ -36,7 +36,7 @@ func TestGetLogs(t *testing.T) {
 	cfg := config.DefaultConfig()
 
 	t.Run("LogFileNotEnabled", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		grpcSrv := NewServerServiceServer(s)
 		req := &serverpb.GetLogsRequest{}
 		resp, err := grpcSrv.GetLogs(context.Background(), req)
@@ -54,7 +54,7 @@ func TestGetLogs(t *testing.T) {
 		cfg := cfg
 		cfg.LogFilePath = logFilePath
 		cfg.LogFileEnabled = true
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		s.EnableLogFile()
 		defer s.CloseLogger()
 		grpcSrv := NewServerServiceServer(s)
@@ -80,7 +80,7 @@ func TestGetLogs(t *testing.T) {
 		cfg := cfg
 		cfg.LogFilePath = logFilePath
 		cfg.LogFileEnabled = true
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		s.EnableLogFile()
 		defer s.CloseLogger()
 		grpcSrv := NewServerServiceServer(s)

--- a/cmd/kvdbserver/server/auth_test.go
+++ b/cmd/kvdbserver/server/auth_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hollowdll/kvdb"
 	"github.com/hollowdll/kvdb/cmd/kvdbserver/config"
 	"github.com/hollowdll/kvdb/cmd/kvdbserver/server"
 	"github.com/hollowdll/kvdb/internal/common"
-	"github.com/hollowdll/kvdb/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -19,7 +19,7 @@ func TestAuthorizeIncomingRpcCall(t *testing.T) {
 	cfg := config.DefaultConfig()
 
 	t.Run("PasswordEnabled", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		password := "pass321"
 		s.EnablePasswordProtection(password)
 
@@ -29,13 +29,13 @@ func TestAuthorizeIncomingRpcCall(t *testing.T) {
 	})
 
 	t.Run("PasswordDisabled", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		err := s.AuthorizeIncomingRpcCall(context.Background())
 		assert.NoErrorf(t, err, "expected no error; error = %s", err)
 	})
 
 	t.Run("InvalidCredentials", func(t *testing.T) {
-		s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
+		s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 		password := "pass321!"
 		s.EnablePasswordProtection(password)
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -16,15 +16,9 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func DisabledLogger() kvdb.Logger {
-	lg := kvdb.NewDefaultLogger()
-	lg.Disable()
-	return lg
-}
-
 func StartTestServer(cfg config.ServerConfig) (*server.KvdbServer, *grpc.Server, int) {
 	fmt.Fprint(os.Stderr, "creating test server\n")
-	s := server.NewKvdbServer(cfg, DisabledLogger())
+	s := server.NewKvdbServer(cfg, kvdb.DisabledLogger())
 	s.CreateDefaultDatabase(cfg.DefaultDB)
 	gs := grpcserver.SetupGrpcServer(s)
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,11 +1,95 @@
 package testutil
 
 import (
+	"crypto/x509"
+	"fmt"
 	"github.com/hollowdll/kvdb"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/hollowdll/kvdb/cmd/kvdbserver/config"
+	grpcserver "github.com/hollowdll/kvdb/cmd/kvdbserver/grpc"
+	"github.com/hollowdll/kvdb/cmd/kvdbserver/server"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func DisabledLogger() kvdb.Logger {
 	lg := kvdb.NewDefaultLogger()
 	lg.Disable()
 	return lg
+}
+
+func StartTestServer(cfg config.ServerConfig) (*server.KvdbServer, *grpc.Server, int) {
+	fmt.Fprint(os.Stderr, "creating test server\n")
+	s := server.NewKvdbServer(cfg, DisabledLogger())
+	s.CreateDefaultDatabase(cfg.DefaultDB)
+	gs := grpcserver.SetupGrpcServer(s)
+
+	lis, err := net.Listen("tcp", ":0")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to listen: %v\n", err)
+	}
+	port := lis.Addr().(*net.TCPAddr).Port
+	s.Cfg.PortInUse = uint16(port)
+	connLis := server.NewClientConnListener(lis, s, cfg.MaxClientConnections)
+	s.ClientConnListener = connLis
+	fmt.Fprintf(os.Stderr, "test server listening at %v\n", lis.Addr())
+
+	go func() {
+		if err := gs.Serve(connLis); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to serve gRPC: %v\n", err)
+		}
+	}()
+
+	return s, gs, port
+}
+
+func StopTestServer(gs *grpc.Server) {
+	fmt.Fprint(os.Stderr, "stopping test server\n")
+	gs.Stop()
+}
+
+func DefaultConfig() config.ServerConfig {
+	return config.DefaultConfig()
+}
+
+func TLSConfig() config.ServerConfig {
+	tlsCertPath, err := filepath.Abs("../../tls/test-cert/kvdbserver.crt")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get TLS certificate path: %v\n", err)
+	}
+	tlsPrivKeyPath, err := filepath.Abs("../../tls/test-cert/kvdbserver.key")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get TLS private key path: %v\n", err)
+	}
+	cfg := config.DefaultConfig()
+	cfg.TLSEnabled = true
+	cfg.TLSCertPath = tlsCertPath
+	cfg.TLSPrivKeyPath = tlsPrivKeyPath
+	return cfg
+}
+
+func GetServerAddress(port int) string {
+	return fmt.Sprintf("localhost:%d", port)
+}
+
+func InsecureConnection(address string) (*grpc.ClientConn, error) {
+	return grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+}
+
+func SecureConnection(address string) (*grpc.ClientConn, error) {
+	certBytes, err := os.ReadFile("../../tls/test-cert/kvdbserver.crt")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read TLS certificate: %v\n", err)
+	}
+	certPool := x509.NewCertPool()
+	if !certPool.AppendCertsFromPEM(certBytes) {
+		fmt.Fprint(os.Stderr, "failed to parse certificate\n")
+	}
+
+	creds := credentials.NewClientTLSFromCert(certPool, "")
+	return grpc.NewClient(address, grpc.WithTransportCredentials(creds))
 }

--- a/logger.go
+++ b/logger.go
@@ -79,6 +79,12 @@ func NewDefaultLogger() *DefaultLogger {
 	return lg
 }
 
+func DisabledLogger() *DefaultLogger {
+	lg := NewDefaultLogger()
+	lg.Disable()
+	return lg
+}
+
 func (l *DefaultLogger) SetLogLevel(level LogLevel) {
 	l.logLevel = level
 }

--- a/tests/benchmark/string_kv_test.go
+++ b/tests/benchmark/string_kv_test.go
@@ -1,0 +1,72 @@
+package benchmark
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hollowdll/kvdb/api/v0/kvpb"
+	"github.com/hollowdll/kvdb/internal/testutil"
+)
+
+const timeout = time.Second * 3
+
+func BenchmarkSetString(b *testing.B) {
+	cfg := testutil.DefaultConfig()
+	_, gs, port := testutil.StartTestServer(cfg)
+	defer testutil.StopTestServer(gs)
+	address := testutil.GetServerAddress(port)
+	conn, err := testutil.InsecureConnection(address)
+	if err != nil {
+		b.Fatalf("setting up connection failed: %v", err)
+	}
+	defer conn.Close()
+	client := kvpb.NewStringKVServiceClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			req := &kvpb.SetStringRequest{
+				Key:   "key",
+				Value: []byte("value"),
+			}
+			client.SetString(ctx, req)
+		}
+	})
+}
+
+func BenchmarkGetString(b *testing.B) {
+	cfg := testutil.DefaultConfig()
+	_, gs, port := testutil.StartTestServer(cfg)
+	defer testutil.StopTestServer(gs)
+	address := testutil.GetServerAddress(port)
+	conn, err := testutil.InsecureConnection(address)
+	if err != nil {
+		b.Fatalf("setting up connection failed: %v", err)
+	}
+	defer conn.Close()
+	client := kvpb.NewStringKVServiceClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	reqSet := &kvpb.SetStringRequest{
+		Key:   "key",
+		Value: []byte("value"),
+	}
+	_, err = client.SetString(ctx, reqSet)
+	if err != nil {
+		b.Fatalf("failed to set string KV: %v", err)
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			req := &kvpb.GetStringRequest{
+				Key: "key",
+			}
+			client.GetString(ctx, req)
+		}
+	})
+}

--- a/tests/integration/auth_test.go
+++ b/tests/integration/auth_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hollowdll/kvdb/api/v0/serverpb"
 	"github.com/hollowdll/kvdb/internal/common"
+	"github.com/hollowdll/kvdb/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -14,15 +15,15 @@ import (
 )
 
 func TestPasswordAuth(t *testing.T) {
-	cfg := defaultConfig()
+	cfg := testutil.DefaultConfig()
 	password := "pass123"
-	s, gs, port := startTestServer(cfg)
-	defer gs.Stop()
+	s, gs, port := testutil.StartTestServer(cfg)
+	defer testutil.StopTestServer(gs)
 	s.EnablePasswordProtection(password)
-	address := getServerAddress(port)
+	address := testutil.GetServerAddress(port)
 
 	t.Run("WithPassword", func(t *testing.T) {
-		conn, err := insecureConnection(address)
+		conn, err := testutil.InsecureConnection(address)
 		require.NoErrorf(t, err, "expected connection but connection failed: %v", err)
 		defer conn.Close()
 		client := serverpb.NewServerServiceClient(conn)
@@ -37,7 +38,7 @@ func TestPasswordAuth(t *testing.T) {
 	})
 
 	t.Run("WithoutPassword", func(t *testing.T) {
-		conn, err := insecureConnection(address)
+		conn, err := testutil.InsecureConnection(address)
 		require.NoErrorf(t, err, "expected connection but connection failed: %v", err)
 		defer conn.Close()
 		client := serverpb.NewServerServiceClient(conn)
@@ -58,7 +59,7 @@ func TestPasswordAuth(t *testing.T) {
 	})
 
 	t.Run("InvalidCredentials", func(t *testing.T) {
-		conn, err := insecureConnection(address)
+		conn, err := testutil.InsecureConnection(address)
 		require.NoErrorf(t, err, "expected connection but connection failed: %v", err)
 		defer conn.Close()
 		client := serverpb.NewServerServiceClient(conn)

--- a/tests/integration/connection_test.go
+++ b/tests/integration/connection_test.go
@@ -5,25 +5,26 @@ import (
 	"testing"
 
 	"github.com/hollowdll/kvdb/api/v0/serverpb"
+	"github.com/hollowdll/kvdb/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 )
 
 func TestMaxClientConnections(t *testing.T) {
 	var maxConnections uint32 = 5
-	cfg := defaultConfig()
+	cfg := testutil.DefaultConfig()
 	cfg.MaxClientConnections = maxConnections
-	_, gs, port := startTestServer(cfg)
-	defer gs.Stop()
+	_, gs, port := testutil.StartTestServer(cfg)
+	defer testutil.StopTestServer(gs)
 
-	address := getServerAddress(port)
+	address := testutil.GetServerAddress(port)
 	connections := make([]*grpc.ClientConn, maxConnections+5)
 	req := &serverpb.GetServerInfoRequest{}
 	ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 	defer cancel()
 
 	for i := 0; i < len(connections); i++ {
-		conn, err := insecureConnection(address)
+		conn, err := testutil.InsecureConnection(address)
 		assert.NoErrorf(t, err, "expected no error; error = %v", err)
 
 		client := serverpb.NewServerServiceClient(conn)
@@ -43,7 +44,7 @@ func TestMaxClientConnections(t *testing.T) {
 		}
 	}
 
-	conn, err := insecureConnection(address)
+	conn, err := testutil.InsecureConnection(address)
 	assert.NoErrorf(t, err, "expected no error; error = %v", err)
 
 	client := serverpb.NewServerServiceClient(conn)

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -1,21 +1,9 @@
 package integration
 
 import (
-	"crypto/x509"
-	"fmt"
-	"net"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
-
-	"github.com/hollowdll/kvdb/cmd/kvdbserver/config"
-	grpcserver "github.com/hollowdll/kvdb/cmd/kvdbserver/grpc"
-	"github.com/hollowdll/kvdb/cmd/kvdbserver/server"
-	"github.com/hollowdll/kvdb/internal/testutil"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 const ctxTimeout = time.Second * 5
@@ -23,71 +11,4 @@ const ctxTimeout = time.Second * 5
 func TestMain(m *testing.M) {
 	code := m.Run()
 	os.Exit(code)
-}
-
-func startTestServer(cfg config.ServerConfig) (*server.KvdbServer, *grpc.Server, int) {
-	fmt.Fprint(os.Stderr, "creating test server ...\n")
-	s := server.NewKvdbServer(cfg, testutil.DisabledLogger())
-	s.CreateDefaultDatabase(cfg.DefaultDB)
-	gs := grpcserver.SetupGrpcServer(s)
-
-	lis, err := net.Listen("tcp", ":0")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to listen: %v\n", err)
-	}
-	port := lis.Addr().(*net.TCPAddr).Port
-	s.Cfg.PortInUse = uint16(port)
-	connLis := server.NewClientConnListener(lis, s, cfg.MaxClientConnections)
-	s.ClientConnListener = connLis
-	fmt.Fprintf(os.Stderr, "test server listening at %v\n", lis.Addr())
-
-	go func() {
-		if err := gs.Serve(connLis); err != nil {
-			fmt.Fprintf(os.Stderr, "failed to serve gRPC: %v\n", err)
-		}
-	}()
-
-	return s, gs, port
-}
-
-func defaultConfig() config.ServerConfig {
-	return config.DefaultConfig()
-}
-
-func tlsConfig() config.ServerConfig {
-	tlsCertPath, err := filepath.Abs("../../tls/test-cert/kvdbserver.crt")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to get TLS certificate path: %v\n", err)
-	}
-	tlsPrivKeyPath, err := filepath.Abs("../../tls/test-cert/kvdbserver.key")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to get TLS private key path: %v\n", err)
-	}
-	cfg := config.DefaultConfig()
-	cfg.TLSEnabled = true
-	cfg.TLSCertPath = tlsCertPath
-	cfg.TLSPrivKeyPath = tlsPrivKeyPath
-	return cfg
-}
-
-func getServerAddress(port int) string {
-	return fmt.Sprintf("localhost:%d", port)
-}
-
-func insecureConnection(address string) (*grpc.ClientConn, error) {
-	return grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
-}
-
-func secureConnection(address string) (*grpc.ClientConn, error) {
-	certBytes, err := os.ReadFile("../../tls/test-cert/kvdbserver.crt")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to read TLS certificate: %v\n", err)
-	}
-	certPool := x509.NewCertPool()
-	if !certPool.AppendCertsFromPEM(certBytes) {
-		fmt.Fprint(os.Stderr, "failed to parse certificate\n")
-	}
-
-	creds := credentials.NewClientTLSFromCert(certPool, "")
-	return grpc.NewClient(address, grpc.WithTransportCredentials(creds))
 }

--- a/tests/integration/tls_test.go
+++ b/tests/integration/tls_test.go
@@ -5,17 +5,18 @@ import (
 	"testing"
 
 	"github.com/hollowdll/kvdb/api/v0/serverpb"
+	"github.com/hollowdll/kvdb/internal/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGetServerInfoWithTLS(t *testing.T) {
-	cfg := tlsConfig()
-	_, gs, port := startTestServer(cfg)
-	defer gs.Stop()
-	address := getServerAddress(port)
+	cfg := testutil.TLSConfig()
+	_, gs, port := testutil.StartTestServer(cfg)
+	defer testutil.StopTestServer(gs)
+	address := testutil.GetServerAddress(port)
 
 	t.Run("WithCredentials", func(t *testing.T) {
-		conn, err := secureConnection(address)
+		conn, err := testutil.SecureConnection(address)
 		require.NoErrorf(t, err, "expected connection but connection failed: %v", err)
 		defer conn.Close()
 		client := serverpb.NewServerServiceClient(conn)
@@ -29,7 +30,7 @@ func TestGetServerInfoWithTLS(t *testing.T) {
 	})
 
 	t.Run("WithoutCredentials", func(t *testing.T) {
-		conn, err := insecureConnection(address)
+		conn, err := testutil.InsecureConnection(address)
 		require.NoErrorf(t, err, "expected connection but connection failed: %v", err)
 		defer conn.Close()
 		client := serverpb.NewServerServiceClient(conn)


### PR DESCRIPTION
Added benchmark tests for SetString and GetString RPCs. Currently no sophisticated benchmarking.