### PR TITLE
Add verbose logs config and more logging

### DIFF
--- a/cmd/kvdbserver/config/config.go
+++ b/cmd/kvdbserver/config/config.go
@@ -124,6 +124,10 @@ func LoadConfig(lg kvdb.Logger) ServerConfig {
 	lg.Infof("Using log level %s", logLevelStr)
 	lg.SetLogLevel(logLevel)
 
+	if viper.GetBool(ConfigKeyVerboseLogsEnabled) {
+		lg.Info("verbose logs are enabled")
+	}
+
 	return ServerConfig{
 		LogFileEnabled:       viper.GetBool(ConfigKeyLogFileEnabled),
 		TLSEnabled:           viper.GetBool(ConfigKeyTLSEnabled),

--- a/cmd/kvdbserver/config/config.go
+++ b/cmd/kvdbserver/config/config.go
@@ -15,8 +15,6 @@ const (
 	configFileType string = "yaml"
 	logFileName    string = "kvdbserver.log"
 
-	// EnvPrefix is the prefix that environment variables use.
-	EnvPrefix string = "KVDB"
 	// ConfigKeyPort is the configuration key for port.
 	ConfigKeyPort string = "port"
 	// ConfigKeyDebugEnabled is the configuration key for debug mode.
@@ -35,13 +33,18 @@ const (
 	ConfigKeyMaxClientConnections string = "max_client_connections"
 	// ConfigKeyLogLevel is the configuration key for log level.
 	ConfigKeyLogLevel string = "log_level"
+	// VerboseLogsEnabled is the configuration key for enabling verbose logs.
+	ConfigKeyVerboseLogsEnabled string = "verbose_logs_enabled"
 
+	// EnvPrefix is the prefix that environment variables use.
+	EnvPrefix string = "KVDB"
 	// EnvVarPassword is the environment variable for server password.
 	EnvVarPassword string = EnvPrefix + "_PASSWORD"
 
 	DefaultLogFileEnabled       bool   = false
 	DefaultTLSEnabled           bool   = false
 	DefaultDebugEnabled         bool   = false
+	DefaultVerboseLogsEnabled   bool   = false
 	DefaultDatabase             string = "default"
 	DefaultPort                 uint16 = common.ServerDefaultPort
 	DefaultLogFilePath          string = ""
@@ -55,9 +58,10 @@ const (
 
 // ServerConfig holds the server's configuration.
 type ServerConfig struct {
-	LogFileEnabled bool
-	TLSEnabled     bool
-	DebugEnabled   bool
+	LogFileEnabled     bool
+	TLSEnabled         bool
+	DebugEnabled       bool
+	VerboseLogsEnabled bool
 
 	// The name of the default database that is created at server startup.
 	DefaultDB string
@@ -100,6 +104,7 @@ func LoadConfig(lg kvdb.Logger) ServerConfig {
 	viper.SetDefault(ConfigKeyDefaultDatabase, DefaultDatabase)
 	viper.SetDefault(ConfigKeyLogFileEnabled, DefaultLogFileEnabled)
 	viper.SetDefault(ConfigKeyTLSEnabled, DefaultTLSEnabled)
+	viper.SetDefault(ConfigKeyVerboseLogsEnabled, DefaultVerboseLogsEnabled)
 	viper.SetDefault(ConfigKeyTLSCertPath, DefaultTLSCertPath)
 	viper.SetDefault(ConfigKeyTLSPrivKeyPath, DefaultTLSPrivKeyPath)
 	viper.SetDefault(ConfigKeyMaxClientConnections, DefaultMaxClientConnections)
@@ -123,6 +128,7 @@ func LoadConfig(lg kvdb.Logger) ServerConfig {
 		LogFileEnabled:       viper.GetBool(ConfigKeyLogFileEnabled),
 		TLSEnabled:           viper.GetBool(ConfigKeyTLSEnabled),
 		DebugEnabled:         viper.GetBool(ConfigKeyDebugEnabled),
+		VerboseLogsEnabled:   viper.GetBool(ConfigKeyVerboseLogsEnabled),
 		DefaultDB:            viper.GetString(ConfigKeyDefaultDatabase),
 		LogFilePath:          filepath.Join(dataDirPath, logFileName),
 		MaxKeysPerDB:         DefaultMaxKeysPerDB,
@@ -140,6 +146,7 @@ func DefaultConfig() ServerConfig {
 		LogFileEnabled:       DefaultLogFileEnabled,
 		TLSEnabled:           DefaultTLSEnabled,
 		DebugEnabled:         DefaultDebugEnabled,
+		VerboseLogsEnabled:   DefaultVerboseLogsEnabled,
 		DefaultDB:            DefaultDatabase,
 		LogFilePath:          DefaultLogFilePath,
 		MaxKeysPerDB:         DefaultMaxKeysPerDB,

--- a/cmd/kvdbserver/grpc/db/db.go
+++ b/cmd/kvdbserver/grpc/db/db.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hollowdll/kvdb/api/v0/dbpb"
 	grpcerrors "github.com/hollowdll/kvdb/cmd/kvdbserver/grpc/errors"
 	"github.com/hollowdll/kvdb/cmd/kvdbserver/server"
-	"github.com/hollowdll/kvdb/cmd/kvdbserver/validation"
 )
 
 type DBServiceServer struct {
@@ -20,10 +19,6 @@ func NewDBServiceServer(s *server.KvdbServer) dbpb.DBServiceServer {
 
 // CreateDB is the implementation of RPC CreateDB.
 func (s *DBServiceServer) CreateDB(ctx context.Context, req *dbpb.CreateDBRequest) (res *dbpb.CreateDBResponse, err error) {
-	if err = validation.ValidateDBName(req.DbName); err != nil {
-		return nil, grpcerrors.ToGrpcError(err)
-	}
-
 	res, err = s.srv.CreateDB(ctx, req)
 	if err != nil {
 		return nil, grpcerrors.ToGrpcError(err)

--- a/cmd/kvdbserver/grpc/kv/hashmap_key.go
+++ b/cmd/kvdbserver/grpc/kv/hashmap_key.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hollowdll/kvdb/api/v0/kvpb"
 	grpcerrors "github.com/hollowdll/kvdb/cmd/kvdbserver/grpc/errors"
 	"github.com/hollowdll/kvdb/cmd/kvdbserver/server"
-	"github.com/hollowdll/kvdb/cmd/kvdbserver/validation"
 )
 
 type HashMapKVServiceServer struct {
@@ -20,10 +19,6 @@ func NewHashMapKVServiceServer(s *server.KvdbServer) kvpb.HashMapKVServiceServer
 
 // SetHashMap is the implementation of RPC SetHashMap.
 func (s *HashMapKVServiceServer) SetHashMap(ctx context.Context, req *kvpb.SetHashMapRequest) (res *kvpb.SetHashMapResponse, err error) {
-	if err = validation.ValidateDBKey(req.Key); err != nil {
-		return nil, grpcerrors.ToGrpcError(err)
-	}
-
 	res, err = s.srv.SetHashMap(ctx, req)
 	if err != nil {
 		return nil, grpcerrors.ToGrpcError(err)

--- a/cmd/kvdbserver/grpc/kv/string_key.go
+++ b/cmd/kvdbserver/grpc/kv/string_key.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hollowdll/kvdb/api/v0/kvpb"
 	grpcerrors "github.com/hollowdll/kvdb/cmd/kvdbserver/grpc/errors"
 	"github.com/hollowdll/kvdb/cmd/kvdbserver/server"
-	"github.com/hollowdll/kvdb/cmd/kvdbserver/validation"
 )
 
 type StringKVServiceServer struct {
@@ -20,10 +19,6 @@ func NewStringKVServiceServer(s *server.KvdbServer) kvpb.StringKVServiceServer {
 
 // SetString is the implementation of RPC SetString.
 func (s *StringKVServiceServer) SetString(ctx context.Context, req *kvpb.SetStringRequest) (res *kvpb.SetStringResponse, err error) {
-	if err = validation.ValidateDBKey(req.Key); err != nil {
-		return nil, grpcerrors.ToGrpcError(err)
-	}
-
 	res, err = s.srv.SetString(ctx, req)
 	if err != nil {
 		return nil, grpcerrors.ToGrpcError(err)

--- a/cmd/kvdbserver/server/api.go
+++ b/cmd/kvdbserver/server/api.go
@@ -116,7 +116,7 @@ func (s *KvdbServer) GetLogs(ctx context.Context, req *serverpb.GetLogsRequest) 
 	defer s.mu.RUnlock()
 
 	if !s.Cfg.LogFileEnabled {
-		lg.Debugf("Logs were requested but the log file is not enabled. Consider enabling it.")
+		lg.Debug("Logs were requested but the log file is not enabled. Consider enabling it.")
 		return nil, kvdberrors.ErrLogFileNotEnabled
 	}
 

--- a/cmd/kvdbserver/server/api.go
+++ b/cmd/kvdbserver/server/api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hollowdll/kvdb/api/v0/dbpb"
 	"github.com/hollowdll/kvdb/api/v0/kvpb"
 	"github.com/hollowdll/kvdb/api/v0/serverpb"
+	"github.com/hollowdll/kvdb/cmd/kvdbserver/validation"
 	kvdberrors "github.com/hollowdll/kvdb/errors"
 	"github.com/hollowdll/kvdb/internal/common"
 	"github.com/hollowdll/kvdb/version"
@@ -131,6 +132,10 @@ func (s *KvdbServer) CreateDB(ctx context.Context, req *dbpb.CreateDBRequest) (*
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if err := validation.ValidateDBName(req.DbName); err != nil {
+		return nil, err
+	}
+
 	if s.dbExists(req.DbName) {
 		return nil, kvdberrors.ErrDatabaseExists
 	}
@@ -245,6 +250,10 @@ func (s *KvdbServer) SetString(ctx context.Context, req *kvpb.SetStringRequest) 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
+	if err := validation.ValidateDBKey(req.Key); err != nil {
+		return nil, err
+	}
+
 	dbName := s.GetDBNameFromContext(ctx)
 	if !s.dbExists(dbName) {
 		return nil, kvdberrors.ErrDatabaseNotFound
@@ -276,6 +285,10 @@ func (s *KvdbServer) GetString(ctx context.Context, req *kvpb.GetStringRequest) 
 func (s *KvdbServer) SetHashMap(ctx context.Context, req *kvpb.SetHashMapRequest) (*kvpb.SetHashMapResponse, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+
+	if err := validation.ValidateDBKey(req.Key); err != nil {
+		return nil, err
+	}
 
 	dbName := s.GetDBNameFromContext(ctx)
 	if !s.dbExists(dbName) {

--- a/docs/kvdbserver.md
+++ b/docs/kvdbserver.md
@@ -35,6 +35,7 @@ tls_cert_path: ""
 tls_enabled: false
 tls_private_key_path: ""
 log_level: info
+verbose_logs_enabled: false
 ```
 
 Meaning of fields:
@@ -48,6 +49,7 @@ Meaning of fields:
 - `tls_enabled`: Enable TLS. If enabled, connections will be encrypted. Can be true or false.
 - `tls_private_key_path`: The path to the TLS private key.
 - `log_level`: The log level. Can be debug, info, warning, error, or fatal.
+- `verbose_logs_enabled`: Enable verbose logs. Verbose logs show more information and details. Typically used with debug log level for debugging purposes.
 
 # Environment variables
 
@@ -65,6 +67,7 @@ Below is a list of all environment variables:
 - `KVDB_TLS_PRIVATE_KEY_PATH`: The path to the TLS private key.
 - `KVDB_MAX_CLIENT_CONNECTIONS`: The maximum number of active client connections allowed.
 - `KVDB_LOG_LEVEL`: The log level. Can be debug, info, warning, error, or fatal.
+- `KVDB_VERBOSE_LOGS_ENABLED`: Enable verbose logs. Verbose logs show more information and details. Typically used with debug log level for debugging purposes.
 
 # Debug mode
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -38,14 +38,10 @@ var (
 
 	// ErrMissingMetadata is returned when gRPC requires metadata
 	// but it is missing.
-	//
-	// DEPRECATED.
 	ErrMissingMetadata = errors.New("missing metadata")
 
 	// ErrMissingKeyInMetadata is returned when a required key is missing
 	// in gRPC metadata.
-	//
-	// DEPRECATED.
 	ErrMissingKeyInMetadata = errors.New("missing key in metadata")
 
 	// ErrInvalidCredentials is returned in authorization process

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,29 +1,29 @@
 package errors
 
-import "errors"
+import (
+	"errors"
+)
 
 var (
 	// ErrDatabaseNotFound is returned when a database couldn't be found.
 	ErrDatabaseNotFound = errors.New("database not found")
 
-	// ErrDatabaseExists is returned when creating a database that already exists.
+	// ErrDatabaseExists is returned when setting a database name that already exists.
 	ErrDatabaseExists = errors.New("database already exists")
 
-	// ErrDatabaseNameEmpty is returned when creating a database with a blank name.
+	// ErrDatabaseNameRequired is returned when setting a blank database name.
 	ErrDatabaseNameRequired = errors.New("database name required")
 
-	// ErrDatabaseNameTooLong is returned when creating a database with a name
-	// that is larger than DbNameMaxSize.
+	// ErrDatabaseNameTooLong is returned when setting a database name that is too long.
 	ErrDatabaseNameTooLong = errors.New("database name too long")
 
-	// ErrDatabaseNameInvalid is returned when creating a database with a name
-	// that contains invalid characters.
+	// ErrDatabaseNameInvalid is returned when setting a database name that contains invalid characters.
 	ErrDatabaseNameInvalid = errors.New("database name contains invalid characters")
 
 	// ErrDatabaseKeyRequired is returned when inserting a key with a blank name.
 	ErrDatabaseKeyRequired = errors.New("key required")
 
-	// ErrDatabaseKeyTooLong is returned when inserting a key that is larger than DbKeyMaxSize.
+	// ErrDatabaseKeyTooLong is returned when inserting a key that is too long.
 	ErrDatabaseKeyTooLong = errors.New("key too long")
 
 	// ErrDatabaseKeyInvalid is returned when inserting a key with a name that contains


### PR DESCRIPTION
The verbosity of some logs can now be controlled with a `verbose_logs_enabled` configuration.